### PR TITLE
Move some (partial) classes to common

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/ElementModel/PocoBuilderExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/ElementModel/PocoBuilderExtensions.cs
@@ -1,0 +1,110 @@
+﻿using Hl7.Fhir.Model;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Hl7.Fhir.ElementModel
+{
+    public static class PocoBuilderExtensions
+    {
+        /// <summary>
+        /// Parses a bindeable type (code, Coding, CodeableConcept, Quantity, string, uri) into a FHIR coded datatype.
+        /// Extensions will be parsed from the 'value' of the (simple) extension.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <returns>An Element of a coded type (code, Coding or CodeableConcept) dependin on the instance type,
+        /// or null if no bindable instance data was found</returns>
+        /// <remarks>The instance type is mapped to a codable type as follows:
+        ///   'code' => code
+        ///   'Coding' => Coding
+        ///   'CodeableConcept' => CodeableConcept
+        ///   'Quantity' => Coding
+        ///   'Extension' => depends on value[x]
+        ///   'string' => code
+        ///   'uri' => code
+        /// </remarks>
+        public static Element ParseBindable(this ITypedElement instance)
+        {
+
+            return instance.InstanceType switch
+            {
+                "code" => instance.ParsePrimitive<Code>(),
+                "string" => new Code(instance.ParsePrimitive<FhirString>()?.Value),
+                "uri" => new Code(instance.ParsePrimitive<FhirUri>()?.Value),
+                "Coding" => instance.ParseCoding(),
+                "CodeableConcept" => instance.ParseCodeableConcept(),
+                "Quantity" => parseQuantity(),
+                "Extension" => parseExtension(),
+                _ => null,
+            };
+
+            Coding parseQuantity()
+            {
+                var newCoding = new Coding();
+                var q = instance.ParseQuantity();
+                newCoding.Code = q.Code;
+                newCoding.System = q.System ?? "http://unitsofmeasure.org";
+                return newCoding;
+            }
+
+            Element parseExtension()
+            {
+                var valueChild = instance.Children("value").FirstOrDefault();
+                return valueChild?.ParseBindable();
+            }
+        }
+
+        public static Model.Quantity ParseQuantity(this ITypedElement instance)
+        {
+            var newQuantity = new Quantity
+            {
+                Value = instance.Children("value").SingleOrDefault()?.Value as decimal?,
+                Unit = instance.Children("unit").GetString(),
+                System = instance.Children("system").GetString(),
+                Code = instance.Children("code").GetString()
+            };
+
+            var comp = instance.Children("comparator").GetString();
+            if (comp != null)
+                newQuantity.ComparatorElement = new Code<Quantity.QuantityComparator> { ObjectValue = comp };
+
+            return newQuantity;
+        }
+
+        public static T ParsePrimitive<T>(this ITypedElement instance) where T : PrimitiveType, new()
+                    => new T() { ObjectValue = instance.Value };
+
+
+        public static Coding ParseCoding(this ITypedElement instance)
+        {
+            return new Coding()
+            {
+                System = instance.Children("system").GetString(),
+                Version = instance.Children("version").GetString(),
+                Code = instance.Children("code").GetString(),
+                Display = instance.Children("display").GetString(),
+                UserSelected = instance.Children("userSelected").SingleOrDefault()?.Value as bool?
+            };
+        }
+
+        public static ResourceReference ParseResourceReference(this ITypedElement instance)
+        {
+            return new ResourceReference()
+            {
+                Reference = instance.Children("reference").GetString(),
+                Display = instance.Children("display").GetString()
+            };
+        }
+
+        public static CodeableConcept ParseCodeableConcept(this ITypedElement instance)
+        {
+            return new CodeableConcept()
+            {
+                Coding =
+                    instance.Children("coding").Select(codingNav => codingNav.ParseCoding()).ToList(),
+                Text = instance.Children("text").GetString()
+            };
+        }
+
+        public static string GetString(this IEnumerable<ITypedElement> instance) => instance.SingleOrDefault()?.Value as string;
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco/ElementModel/PocoBuilderExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/ElementModel/PocoBuilderExtensions.cs
@@ -1,4 +1,13 @@
-﻿using Hl7.Fhir.Model;
+﻿/* 
+ * Copyright (c) 2018, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-net-sdk/blob/master/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Support.Poco;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -27,13 +36,13 @@ namespace Hl7.Fhir.ElementModel
 
             return instance.InstanceType switch
             {
-                "code" => instance.ParsePrimitive<Code>(),
-                "string" => new Code(instance.ParsePrimitive<FhirString>()?.Value),
-                "uri" => new Code(instance.ParsePrimitive<FhirUri>()?.Value),
-                "Coding" => instance.ParseCoding(),
-                "CodeableConcept" => instance.ParseCodeableConcept(),
-                "Quantity" => parseQuantity(),
-                "Extension" => parseExtension(),
+                FhirTypeConstants.CODE => instance.ParsePrimitive<Code>(),
+                FhirTypeConstants.STRING => new Code(instance.ParsePrimitive<FhirString>()?.Value),
+                FhirTypeConstants.URI => new Code(instance.ParsePrimitive<FhirUri>()?.Value),
+                FhirTypeConstants.CODING => instance.ParseCoding(),
+                FhirTypeConstants.CODEABLE_CONCEPT => instance.ParseCodeableConcept(),
+                FhirTypeConstants.QUANTITY => parseQuantity(),
+                FhirTypeConstants.EXTENSION => parseExtension(),
                 _ => null,
             };
 

--- a/src/Hl7.Fhir.Support.Poco/ElementModel/ScopedNodeExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/ElementModel/ScopedNodeExtensions.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Fhir.Rest;
+using Hl7.Fhir.Support.Poco;
 using System;
 using System.Linq;
 
@@ -74,7 +75,7 @@ namespace Hl7.Fhir.ElementModel
 
                 foreach (var parent in scopedNode.ParentResources())
                 {
-                    if (parent.InstanceType == "Bundle")
+                    if (parent.InstanceType == FhirTypeConstants.BUNDLE)
                     {
                         var result = parent.BundledResources().FirstOrDefault(br => br.FullUrl == url)?.Resource;
                         if (result != null) return result;
@@ -102,9 +103,9 @@ namespace Hl7.Fhir.ElementModel
             // First, get the url to fetch from the focus
             string url = null;
 
-            if (element.InstanceType == "string" && element.Value is string s) // hmm, we cannot use FhirAllTypes.String.GetLiteral()
+            if (element.InstanceType == FhirTypeConstants.STRING && element.Value is string s)
                 url = s;
-            else if (element.InstanceType == "Reference")  // hmm, we cannot use FhirAllTypes.Reference.GetLiteral()
+            else if (element.InstanceType == FhirTypeConstants.REFERENCE)
                 url = element.ParseResourceReference()?.Reference;
 
             if (url == null) return default;   // nothing found to resolve

--- a/src/Hl7.Fhir.Support.Poco/ElementModel/ScopedNodeExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/ElementModel/ScopedNodeExtensions.cs
@@ -1,0 +1,115 @@
+﻿/* 
+ * Copyright (c) 2017, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using Hl7.Fhir.Rest;
+using System;
+using System.Linq;
+
+namespace Hl7.Fhir.ElementModel
+{
+    public static class ScopedNodeExtensions
+    {
+        public static string MakeAbsolute(this ScopedNode node, string reference) =>
+                     node.MakeAbsolute(new ResourceIdentity(reference)).ToString();
+
+        /// <summary>
+        /// Turn a relative reference into an absolute url, based on the fullUrl of the parent resource
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="identity"></param>
+        /// <returns></returns>
+        /// <remarks>See https://www.hl7.org/fhir/bundle.html#references for more information</remarks>
+        public static ResourceIdentity MakeAbsolute(this ScopedNode node, ResourceIdentity identity)
+        {
+            if (identity.IsRelativeRestUrl)
+            {
+                // Relocate the relative url on the base given in the fullUrl of the entry (if applicable)
+                var fullUrl = node.FullUrl();
+
+                if (fullUrl != null)
+                {
+                    var parentIdentity = new ResourceIdentity(fullUrl);
+
+                    if (parentIdentity.IsAbsoluteRestUrl)
+                        identity = identity.WithBase(parentIdentity.BaseUri);
+                    else if (parentIdentity.IsUrn)
+                        identity = new ResourceIdentity($"{parentIdentity}/{identity.Id}");
+                }
+
+                // Return the identity - will remain relative if we did not find a fullUrl              
+            }
+
+            return identity;
+        }
+
+        public static T Resolve<T>(this T element, string reference, Func<string, T> externalResolver = null) where T : class, ITypedElement
+        {
+            // Then, resolve the url within the instance data first - this is only
+            // possibly if we have a ScopedNode at hand
+            if (element is ScopedNode scopedNode)
+            {
+                var identity = scopedNode.MakeAbsolute(new ResourceIdentity(reference));
+
+                if (identity.IsLocal || identity.IsAbsoluteRestUrl || identity.IsUrn)
+                {
+                    var result = locateResource(identity);
+                    if (result != null) return (T)(object)result;
+                }
+            }
+
+            // Nothing found internally, now try the external resolver
+            if (externalResolver != null)
+                return externalResolver(reference);
+            else
+                return null;
+
+            ScopedNode locateResource(ResourceIdentity identity)
+            {
+                var url = identity.ToString();
+
+                foreach (var parent in scopedNode.ParentResources())
+                {
+                    if (parent.InstanceType == "Bundle")
+                    {
+                        var result = parent.BundledResources().FirstOrDefault(br => br.FullUrl == url)?.Resource;
+                        if (result != null) return result;
+                    }
+                    else
+                    {
+                        if (parent.Id() == url) return parent;
+                        var result = parent.ContainedResources().FirstOrDefault(cr => cr.Id() == url);
+                        if (result != null) return result;
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Where this item is a reference, resolve it to an actual resource, and return that
+        /// </summary>
+        /// <param name="element"></param>
+        /// <param name="externalResolver"></param>
+        /// <returns></returns>
+        public static T Resolve<T>(this T element, Func<string, T> externalResolver = null) where T : class, ITypedElement
+        {
+            // First, get the url to fetch from the focus
+            string url = null;
+
+            if (element.InstanceType == "string" && element.Value is string s) // hmm, we cannot use FhirAllTypes.String.GetLiteral()
+                url = s;
+            else if (element.InstanceType == "Reference")  // hmm, we cannot use FhirAllTypes.Reference.GetLiteral()
+                url = element.ParseResourceReference()?.Reference;
+
+            if (url == null) return default;   // nothing found to resolve
+
+            return Resolve(element, url, externalResolver);
+        }
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco/FhirPath/ElementNavFhirExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/FhirPath/ElementNavFhirExtensions.cs
@@ -1,0 +1,102 @@
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Hl7.FhirPath;
+using Hl7.FhirPath.Expressions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using P = Hl7.Fhir.ElementModel.Types;
+
+namespace Hl7.Fhir.FhirPath
+{
+    public static class ElementNavFhirExtensions
+    {
+        internal static bool _fhirSymbolTableExtensionsAdded = false;
+        public static void PrepareFhirSymbolTableFunctions()
+        {
+            if (!_fhirSymbolTableExtensionsAdded)
+            {
+                _fhirSymbolTableExtensionsAdded = true;
+                Hl7.FhirPath.FhirPathCompiler.DefaultSymbolTable.AddFhirExtensions();
+            }
+        }
+
+        public static SymbolTable AddFhirExtensions(this SymbolTable t)
+        {
+            t.Add("hasValue", (ITypedElement f) => f.HasValue(), doNullProp: false);
+            t.Add("resolve", (ITypedElement f, EvaluationContext ctx) => resolver(f, ctx), doNullProp: false);
+
+            // Pre-normative this function was called htmlchecks, normative is htmlChecks
+            // lets keep both to keep everyone happy.
+            t.Add("htmlchecks", (ITypedElement f) => f.HtmlChecks(), doNullProp: false);
+            t.Add("htmlChecks", (ITypedElement f) => f.HtmlChecks(), doNullProp: false);
+
+            return t;
+
+            static ITypedElement resolver(ITypedElement f, EvaluationContext ctx)
+            {
+                return ctx is FhirEvaluationContext fctx ? f.Resolve(fctx.ElementResolver) : f.Resolve();
+            }
+        }
+
+        /// <summary>
+        /// Check if the node has a value, and not just extensions.
+        /// </summary>
+        /// <param name="focus"></param>
+        /// <returns></returns>
+        public static bool HasValue(this ITypedElement focus)
+        {
+            if (focus == null)
+                return false;
+            if (focus.Value == null)
+                return false;
+            return true;
+        }
+
+        /// <summary>
+        /// Check if the node has a value, and not just extensions.
+        /// </summary>
+        /// <param name="focus"></param>
+        /// <returns></returns>
+        public static bool HtmlChecks(this ITypedElement focus)
+        {
+            if (focus == null)
+                return false;
+            if (focus.Value == null)
+                return false;
+            // Perform the checking of the content for valid html content
+            _ = focus.Value.ToString();
+            // TODO: Perform the checking
+            return true;
+        }
+
+        public static IEnumerable<Base> ToFhirValues(this IEnumerable<ITypedElement> results)
+        {
+            return results.Select(r =>
+            {
+                if (r == null)
+                    return null;
+
+                var fhirValue = r.Annotation<IFhirValueProvider>();
+                if (fhirValue != null)
+                {
+                    return fhirValue.FhirValue;
+                }
+
+                object result = r.Value;
+
+                return result switch
+                {
+                    bool _ => new FhirBoolean((bool)result),
+                    long _ => new Integer((int)(long)result),
+                    decimal _ => new FhirDecimal((decimal)result),
+                    string _ => new FhirString((string)result),
+                    P.Date d => new Date(d.ToString()),
+                    P.Time t => new Time(t.ToString()),
+                    P.DateTime dt => new FhirDateTime(dt.ToDateTimeOffset(TimeSpan.Zero).ToUniversalTime()),
+                    _ => (Base)result
+                };
+            });
+        }
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco/FhirPath/ElementNavFhirExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/FhirPath/ElementNavFhirExtensions.cs
@@ -74,7 +74,7 @@ namespace Hl7.Fhir.FhirPath
         {
             return results.Select(r =>
             {
-                if (r == null)
+                if (r is null)
                     return null;
 
                 var fhirValue = r.Annotation<IFhirValueProvider>();
@@ -87,10 +87,11 @@ namespace Hl7.Fhir.FhirPath
 
                 return result switch
                 {
-                    bool _ => new FhirBoolean((bool)result),
-                    long _ => new Integer((int)(long)result),
-                    decimal _ => new FhirDecimal((decimal)result),
-                    string _ => new FhirString((string)result),
+                    bool b => new FhirBoolean(b),
+                    long l => new Integer64(l),
+                    int i => new Integer(i),
+                    decimal dec => new FhirDecimal(dec),
+                    string s => new FhirString(s),
                     P.Date d => new Date(d.ToString()),
                     P.Time t => new Time(t.ToString()),
                     P.DateTime dt => new FhirDateTime(dt.ToDateTimeOffset(TimeSpan.Zero).ToUniversalTime()),

--- a/src/Hl7.Fhir.Support.Poco/FhirPath/FhirEvaluationContext.cs
+++ b/src/Hl7.Fhir.Support.Poco/FhirPath/FhirEvaluationContext.cs
@@ -1,0 +1,43 @@
+﻿/* 
+ * Copyright (c) 2016, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using Hl7.Fhir.ElementModel;
+using Hl7.FhirPath;
+using System;
+
+namespace Hl7.Fhir.FhirPath
+{
+    public class FhirEvaluationContext : EvaluationContext
+    {
+        /// <summary>Creates a new <see cref="FhirEvaluationContext"/> instance with default property values.</summary>
+        public static new FhirEvaluationContext CreateDefault() => new FhirEvaluationContext();
+
+        /// <summary>Default constructor. Creates a new <see cref="FhirEvaluationContext"/> instance with default property values.</summary>
+        public FhirEvaluationContext() : base()
+        {
+        }
+
+        /// <inheritdoc cref="EvaluationContext.EvaluationContext(ITypedElement)"/>
+        public FhirEvaluationContext(ITypedElement resource) : base(resource)
+        {
+        }
+
+        /// <inheritdoc cref="EvaluationContext.EvaluationContext(ITypedElement, ITypedElement)"/>
+        public FhirEvaluationContext(ITypedElement resource, ITypedElement rootResource) : base(resource, rootResource)
+        {
+        }
+
+        private Func<string, ITypedElement> _elementResolver;
+
+        public Func<string, ITypedElement> ElementResolver
+        {
+            get { return _elementResolver; }
+            set { _elementResolver = value; }
+        }
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco/Hl7.Fhir.Support.Poco.csproj
+++ b/src/Hl7.Fhir.Support.Poco/Hl7.Fhir.Support.Poco.csproj
@@ -47,6 +47,7 @@
     <ProjectReference Include="..\Hl7.Fhir.ElementModel\Hl7.Fhir.ElementModel.csproj" />
     <ProjectReference Include="..\Hl7.Fhir.Support\Hl7.Fhir.Support.csproj" />
     <ProjectReference Include="..\Hl7.Fhir.Serialization\Hl7.Fhir.Serialization.csproj" />
+    <ProjectReference Include="..\Hl7.FhirPath\Hl7.FhirPath.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Hl7.Fhir.Support.Poco/Model/FhirTypeConstants.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/FhirTypeConstants.cs
@@ -1,0 +1,51 @@
+﻿/* 
+ * Copyright (c) 2021, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-net-sdk/blob/master/LICENSE
+ */
+
+namespace Hl7.Fhir.Support.Poco
+{
+    /// <summary>
+    /// List of Fhir types constants. This will be removed when we introduce ModelSpace, but for now we will use this.
+    /// </summary>
+    internal class FhirTypeConstants
+    {
+        // primitive types
+        public const string BOOLEAN = "boolean";
+        public const string INTEGER = "integer";
+        public const string INTEGER64 = "integer64";
+        public const string UNSIGNED_INT = "unsignedInt";
+        public const string POSITIVE_INT = "positiveInt";
+        public const string TIME = "time";
+        public const string DATE = "date";
+        public const string INSTANT = "instant";
+        public const string DATE_TIME = "dateTime";
+        public const string DECIMAL = "decimal";
+        public const string STRING = "string";
+        public const string CODE = "code";
+        public const string ID = "id";
+        public const string URI = "uri";
+        public const string OID = "oid";
+        public const string UUID = "uuid";
+        public const string CANONICAL = "canonical";
+        public const string URL = "url";
+        public const string MARKDOWN = "markdown";
+        public const string BASE64_BINARY = "base64Binary";
+
+        // General-Purpose Data types
+        public const string CODING = "Coding";
+        public const string CODEABLE_CONCEPT = "CodeableConcept";
+        public const string QUANTITY = "Quantity";
+
+        // Special Purpose Data types
+        public const string EXTENSION = "Extension";
+        public const string REFERENCE = "Reference";
+        public const string XHTML = "xhtml";
+
+        // Resource type
+        public const string BUNDLE = "Bundle";
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco/Support/Issue.cs
+++ b/src/Hl7.Fhir.Support.Poco/Support/Issue.cs
@@ -1,0 +1,172 @@
+/* 
+ * Copyright (c) 2016, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using System.Collections.Generic;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.ElementModel;
+using System;
+
+#pragma warning disable 1591 // suppress XML summary warnings
+
+namespace Hl7.Fhir.Support
+{
+    public class Issue
+    {
+        public const string API_OPERATION_OUTCOME_SYSTEM = "http://hl7.org/fhir/dotnet-api-operation-outcome";
+
+        public int Code;
+        public OperationOutcome.IssueSeverity Severity;
+        public OperationOutcome.IssueType Type;
+
+        public CodeableConcept ToCodeableConcept(string text = null) => ToCodeableConcept(Code, text);
+
+        public static CodeableConcept ToCodeableConcept(int issueCode, string text = null) => 
+            new CodeableConcept(API_OPERATION_OUTCOME_SYSTEM, issueCode.ToString(), text);
+
+        public OperationOutcome.IssueComponent ToIssueComponent(string message, ITypedElement location = null) => 
+            ToIssueComponent(message, location?.Location);
+
+        public OperationOutcome.IssueComponent ToIssueComponent(string message, string path = null)
+        {
+            // https://www.hl7.org/fhir/operationoutcome-definitions.html#OperationOutcome.issue.details
+            // Comments: "A human readable description of the error issue SHOULD be placed in details.text."
+
+            // var ic = new OperationOutcome.IssueComponent() { Severity = this.Severity, Code = this.Type, Diagnostics = message };
+            var ic = new OperationOutcome.IssueComponent() { Severity = this.Severity, Code = this.Type };
+
+            // Put numeric code + readable message into a CodeableConcept
+            ic.Details = ToCodeableConcept(message);
+
+            if (path != null) ic.Location = new List<string> { path };
+
+            return ic;
+        }
+
+        internal Issue(int code, OperationOutcome.IssueSeverity severity, OperationOutcome.IssueType type)
+        {
+            Code = code;
+            Severity = severity;
+            Type = type;
+        }
+        /// <summary>Factory method.</summary>
+        public static Issue Create(int code, OperationOutcome.IssueSeverity severity, OperationOutcome.IssueType type) =>
+            new Issue(code, severity, type);
+
+        // Validation resource instance errors
+        public static readonly Issue CONTENT_ELEMENT_MUST_HAVE_VALUE_OR_CHILDREN = Create(1000, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_HAS_UNKNOWN_CHILDREN = Create(1001, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_HAS_INCORRECT_TYPE = Create(1003, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_MUST_MATCH_TYPE = Create(1004, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_VALUE_TOO_LONG = Create(1005, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_INVALID_PRIMITIVE_VALUE = Create(1006, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_DOES_NOT_MATCH_FIXED_VALUE = Create(1008, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_DOES_NOT_MATCH_PATTERN_VALUE = Create(1009, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_CANNOT_DETERMINE_TYPE = Create(1010, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_CHOICE_INVALID_INSTANCE_TYPE = Create(1011, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_FAILS_ERROR_CONSTRAINT = Create(1012, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invariant);
+        public static readonly Issue CONTENT_ELEMENT_FAILS_WARNING_CONSTRAINT = Create(1013, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Invariant);
+        public static readonly Issue CONTENT_REFERENCE_OF_INVALID_KIND = Create(1015, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_CONTAINED_REFERENCE_NOT_RESOLVABLE = Create(1016, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_UNPARSEABLE_REFERENCE = Create(1017, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_REFERENCE_NOT_RESOLVABLE = Create(1018, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_PRIMITIVE_VALUE_TOO_SMALL = Create(1019, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_PRIMITIVE_VALUE_TOO_LARGE = Create(1020, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_PRIMITIVE_VALUE_NOT_COMPARABLE = Create(1021, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_MISMATCHING_PROFILES = Create(1022, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_INVALID_FOR_REQUIRED_BINDING = Create(1023, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_INVALID_FOR_NON_REQUIRED_BINDING = Create(1024, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_TYPE_NOT_BINDEABLE  = Create(1025, OperationOutcome.IssueSeverity.Information, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_FAILS_SLICING_RULE = Create(1026, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_SLICING_OUT_OF_ORDER = Create(1027, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_INCORRECT_OCCURRENCE = Create(1028, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue CONTENT_ELEMENT_NAME_DOESNT_MATCH_DEFINITION = Create(1029, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+
+        public static readonly Issue XSD_VALIDATION_ERROR = Create(1100, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue XSD_VALIDATION_WARNING = Create(1101, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Invalid);
+        public static readonly Issue XSD_CONTENT_POCO_PARSING_FAILED = Create(1102, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid);
+
+        // Profile problems
+        public static readonly Issue PROFILE_ELEMENTDEF_MIN_MAX_USES_UNORDERED_TYPE = Create(2000, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.BusinessRule);
+        public static readonly Issue PROFILE_ELEMENTDEF_MAX_USES_UNORDERED_TYPE = Create(2001, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.BusinessRule);
+        public static readonly Issue PROFILE_ELEMENTDEF_MAXLENGTH_NEGATIVE = Create(2002, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.BusinessRule);
+        public static readonly Issue PROFILE_ELEMENTDEF_CONTAINS_NULL_TYPE = Create(2003, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.BusinessRule);
+        public static readonly Issue PROFILE_ELEMENTDEF_CONTAINS_NO_TYPE_OR_NAMEREF = Create(2004, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.BusinessRule);
+//        public static readonly Issue PROFILE_ELEMENTDEF_NO_PRIMITIVE_REGEX = def(2005, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.BusinessRule);
+        public static readonly Issue PROFILE_ELEMENTDEF_INVALID_NAMEREFERENCE = Create(2006, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.BusinessRule);
+        public static readonly Issue PROFILE_ELEMENTDEF_CARDINALITY_MISSING = Create(2007, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.BusinessRule);
+        public static readonly Issue PROFILE_ELEMENTDEF_IS_EMPTY = Create(2008, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.BusinessRule);
+        public static readonly Issue PROFILE_ELEMENTDEF_INVALID_FHIRPATH_EXPRESSION = Create(2009, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.BusinessRule);
+        public static readonly Issue PROFILE_NO_PROFILE_TO_VALIDATE_AGAINST = Create(2010, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Incomplete);
+        public static readonly Issue PROFILE_ELEMENTDEF_INCORRECT = Create(2012, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.BusinessRule);
+        [Obsolete("This issue will not be raised by the validator anymore. Use 'PROFILE_ELEMENTDEF_INCORRECT' instead.")] // Obsolete on 20190409 by Marco
+        public static readonly Issue PROFILE_INCOMPLETE_BINDING = Create(2011, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Incomplete);
+        public static readonly Issue PROFILE_INSTANCE_MATCHES_MULTIPLE_SLICES = Create(2013, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Structure);
+
+        // Unsupported 
+        public static readonly Issue UNSUPPORTED_SLICING_NOT_SUPPORTED = Create(3000, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.NotSupported);
+        public static readonly Issue UNSUPPORTED_CONSTRAINT_WITHOUT_FHIRPATH = Create(3003, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Incomplete);
+        public static readonly Issue UNSUPPORTED_MIN_MAX_QUANTITY = Create(3004, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.NotSupported);
+        public static readonly Issue UNSUPPORTED_BINDING_NOT_SUPPORTED_BY_SERVICE = Create(3006, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.NotSupported);
+
+        // Non-availability, incomplete data
+        public static readonly Issue UNAVAILABLE_REFERENCED_PROFILE = Create(4000, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Incomplete);
+        public static readonly Issue UNAVAILABLE_NEED_SNAPSHOT = Create(4002, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Incomplete);
+        public static readonly Issue UNAVAILABLE_SNAPSHOT_GENERATION_FAILED = Create(4003, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Incomplete);
+        public static readonly Issue UNAVAILABLE_NEED_DIFFERENTIAL = Create(4004, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Incomplete);
+        public static readonly Issue UNAVAILABLE_REFERENCED_RESOURCE = Create(4005, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Incomplete);
+        public static readonly Issue UNAVAILABLE_TERMINOLOGY_SERVER = Create(4007, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Incomplete);
+        public static readonly Issue UNAVAILABLE_VALIDATE_CODE_FAILED = Create(4008, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Incomplete);
+
+        // Processing information
+        public static readonly Issue PROCESSING_PROGRESS = Create(5000, OperationOutcome.IssueSeverity.Information, OperationOutcome.IssueType.Informational);
+       // public static readonly Issue PROCESSING_CONSTRAINT_VALIDATION_INACTIVEX = Create(5001, OperationOutcome.IssueSeverity.Information, OperationOutcome.IssueType.Informational);
+        public static readonly Issue PROCESSING_START_NESTED_VALIDATION = Create(5002, OperationOutcome.IssueSeverity.Information, OperationOutcome.IssueType.Informational);
+        public static readonly Issue PROCESSING_CATASTROPHIC_FAILURE = Create(5003, OperationOutcome.IssueSeverity.Fatal, OperationOutcome.IssueType.Exception);
+
+        // Terminology specific errors
+        public static readonly Issue TERMINOLOGY_CODE_NOT_IN_VALUESET = Create(6001, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.CodeInvalid);
+        public static readonly Issue TERMINOLOGY_ABSTRACT_CODE_NOT_ALLOWED = Create(6002, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.CodeInvalid);
+        public static readonly Issue TERMINOLOGY_INCORRECT_DISPLAY = Create(6003, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.CodeInvalid);     
+        public static readonly Issue TERMINOLOGY_SERVICE_FAILED = Create(6004, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.NotSupported);
+        public static readonly Issue TERMINOLOGY_NO_CODE_IN_INSTANCE = Create(6005, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.CodeInvalid);
+    }
+
+
+    public static class OperationOutcomeIssueExtensions
+    {
+        public static OperationOutcome NewOutcomeWithIssue(this Issue infoIssue, string message, ITypedElement location)
+        {
+            var outcome = new OperationOutcome();
+            var issue = infoIssue.ToIssueComponent(message, location);
+            outcome.AddIssue(issue);
+            return outcome;
+        }
+
+        public static OperationOutcome NewOutcomeWithIssue(this Issue infoIssue, string message, string location = null)
+        {
+            var outcome = new OperationOutcome();
+            var issue = infoIssue.ToIssueComponent(message, location);
+            outcome.AddIssue(issue);
+            return outcome;
+        }
+
+        public static OperationOutcome.IssueComponent AddIssue(this OperationOutcome outcome, string message, Issue infoIssue, ITypedElement location)
+        {
+            var issue = infoIssue.ToIssueComponent(message, location);
+            outcome.AddIssue(issue);
+            return issue;
+        }
+
+        public static OperationOutcome.IssueComponent AddIssue(this OperationOutcome outcome, string message, Issue infoIssue, string location = null)
+        {
+            var issue = infoIssue.ToIssueComponent(message, location);
+            outcome.AddIssue(issue);
+            return issue;
+        }
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco/Support/ValidationOutcomeExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/Support/ValidationOutcomeExtensions.cs
@@ -1,0 +1,121 @@
+﻿/*
+* Copyright (c) 2016, Firely (info@fire.ly) and contributors
+* See the file CONTRIBUTORS for details.
+*
+* This file is licensed under the BSD 3-Clause license
+*/
+
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Support;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Hl7.Fhir.Support
+{
+
+    public static class ValidationOutcomeExtensions
+    {
+        public static OperationOutcome.IssueComponent AddIssue(this OperationOutcome outcome, OperationOutcome.IssueComponent issue)
+        {
+            outcome.Issue.Add(issue);
+            return issue;
+        }
+
+        public static void AddIssue(this OperationOutcome outcome, params OperationOutcome.IssueComponent[] issue)
+        {
+            outcome.AddIssue((IEnumerable<OperationOutcome.IssueComponent>)issue);
+        }
+
+        public static void AddIssue(this OperationOutcome outcome, IEnumerable<OperationOutcome.IssueComponent> issues)
+        {
+            outcome.Issue.AddRange(issues);
+        }
+
+        public static void Add(this OperationOutcome outcome, OperationOutcome other)
+        {
+            outcome.AddIssue(other.Issue);
+            //foreach (var issue in other.Issue)
+            //{
+            //    //var myIssue = (OperationOutcome.IssueComponent)issue.DeepCopy();
+            //    var myIssue = issue;
+            //    outcome.AddIssue(myIssue);
+            //}
+        }
+
+
+        public static Stopwatch OUTCOME_INCLUDE_TIMER = new Stopwatch();
+
+        public static void Include(this OperationOutcome outcome, OperationOutcome other)
+        {               
+            foreach (var issue in other.Issue)
+            {
+                // var myIssue = (OperationOutcome.IssueComponent)issue.DeepCopy();
+                var myIssue = issue;
+                myIssue.SetHierarchyLevel(myIssue.GetHierarchyLevel() + 1);
+                outcome.AddIssue(myIssue);
+            }
+        }
+
+        public static void Clear(this OperationOutcome outcome)
+        {
+            outcome.Issue.Clear();
+        }
+
+        public static IEnumerable<OperationOutcome.IssueComponent> ListErrors(this OperationOutcome outcome)
+        {
+            return outcome.Issue.Where(issue => !issue.Success);
+        }
+
+        public static IEnumerable<OperationOutcome.IssueComponent> IssuesAt(this OperationOutcome outcome, string path)
+        {
+            return outcome.Issue.Where(issue => issue.IsAt(path));
+        }
+
+        public static IEnumerable<OperationOutcome.IssueComponent> ErrorsAt(this OperationOutcome outcome, string path)
+        {
+            return outcome.ListErrors().Where(issue => issue.IsAt(path));
+        }
+
+        public static IEnumerable<OperationOutcome.IssueComponent> Where(this OperationOutcome outcome,
+                OperationOutcome.IssueSeverity? severity=null, OperationOutcome.IssueType? type=null, int? issueCode = null)
+        {
+            IEnumerable<OperationOutcome.IssueComponent> result = outcome.Issue;
+
+            if (severity != null) result = result.Where(i => i.Severity == severity);
+            if (type != null) result = result.Where(i => i.Code == type);
+            if (issueCode != null) result = result.Where(i => i.Details.Matches(Issue.ToCodeableConcept(issueCode.Value)));
+
+            return result;
+        }
+
+        public static IEnumerable<OperationOutcome.IssueComponent> AtLevel(this OperationOutcome outcome, int level)
+        {
+            return outcome.Issue.Where(i => i.GetHierarchyLevel() == level);
+        }
+
+        public const string OPERATIONOUTCOME_ISSUE_HIERARCHY = "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-hierarchy";
+
+        public static void SetHierarchyLevel(this OperationOutcome.IssueComponent issue, int level)
+        {
+            issue.SetIntegerExtension(OPERATIONOUTCOME_ISSUE_HIERARCHY, level);
+        }
+
+        public static int GetHierarchyLevel(this OperationOutcome.IssueComponent issue)
+        {
+            return issue.GetIntegerExtension(OPERATIONOUTCOME_ISSUE_HIERARCHY).GetValueOrDefault(0);
+        }
+
+        public static bool IsAt(this OperationOutcome.IssueComponent issue, string path)
+        {
+            if (issue.Location != null)
+            {
+                return issue.Location.Contains(path);
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Moved some classes from Core to Common.
- Pay extra attention to extension method `public static T Resolve<T>(this T element, Func<string, T> externalResolver = null) where T : class, ITypedElement` in class `ScopedNodeExtensions`: do we want string constants for this?
- see a list of breaking changes that this PR causes: https://github.com/FirelyTeam/firely-net-sdk/wiki/Breaking-changes-in-3.0