### PR TITLE
TryGetFhirReleaseFromCorePackageName now returns correct result

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Utility/FhirVersionUtility.cs
+++ b/src/Hl7.Fhir.Support.Poco/Utility/FhirVersionUtility.cs
@@ -90,7 +90,7 @@ namespace Hl7.Fhir.Utility
         /// <returns>Official FHIR Release</returns>
         public static FhirRelease FhirReleaseFromMimeVersion(string fhirMimeVersion)
         {
-            if (TryFhirReleaseFromMimeVersion(fhirMimeVersion, out var release))
+            if (TryGetFhirReleaseFromMimeVersion(fhirMimeVersion, out var release))
             {
                 return release.Value;
             }
@@ -106,7 +106,7 @@ namespace Hl7.Fhir.Utility
         /// <param name="fhirMimeVersion">'fhirversion' MIME-Type parameter</param>
         /// <param name="release">Official FHIR Release</param>
         /// <returns>true if the conversion succeeded; false otherwise.</returns>
-        public static bool TryFhirReleaseFromMimeVersion(string fhirMimeVersion, out FhirRelease? release)
+        public static bool TryGetFhirReleaseFromMimeVersion(string fhirMimeVersion, out FhirRelease? release)
         {
             release = fhirMimeVersion switch
             {
@@ -118,6 +118,12 @@ namespace Hl7.Fhir.Utility
                 _ => null
             };
             return release != null;
+        }
+
+        [Obsolete("This method is obsolete. Use TryGetFhirReleaseFromMimeVersion instead")]
+        public static bool TryFhirReleaseFromMimeVersion(string fhirMimeVersion, out FhirRelease? release)
+        {
+            return TryGetFhirReleaseFromMimeVersion(fhirMimeVersion, out release);
         }
 
         /// <summary>
@@ -145,7 +151,7 @@ namespace Hl7.Fhir.Utility
         /// <returns>Official FHIR Release</returns>
         public static FhirRelease FhirReleaseFromCorePackageName(string packageName)
         {
-            if (TryFhirReleaseFromCorePackageName(packageName, out var release))
+            if (TryGetFhirReleaseFromCorePackageName(packageName, out var release))
             {
                 return release.Value;
             }
@@ -161,7 +167,7 @@ namespace Hl7.Fhir.Utility
         /// <param name="packageName">FHIR Core package name</param>
         /// <param name="release">Official FHIR Release</param>
         /// <returns>true if the conversion succeeded; false otherwise</returns>
-        public static bool TryFhirReleaseFromCorePackageName(string packageName, out FhirRelease? release)
+        public static bool TryGetFhirReleaseFromCorePackageName(string packageName, out FhirRelease? release)
         {
             release = packageName switch
             {
@@ -170,8 +176,15 @@ namespace Hl7.Fhir.Utility
                 "hl7.fhir.r5.core" => FhirRelease.R5,
                 _ => null
             };
-            return packageName != null;
+            return release != null;
         }
+
+        [Obsolete("This method is obsolete. Use TryGetFhirReleaseFromCorePackageName instead")]
+        public static bool TryFhirReleaseFromCorePackageName(string packageName, out FhirRelease? release)
+        {
+            return TryGetFhirReleaseFromCorePackageName(packageName, out release);
+        } 
+
 
 
         /// <summary>

--- a/src/Hl7.Fhir.Support.Tests/Utility/FhirVersionTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/Utility/FhirVersionTests.cs
@@ -85,18 +85,18 @@ namespace Hl7.Fhir.Utility.Tests
         public void TestTryFhirVersionFromMimeVersion()
         {
             FhirRelease? version = null;
-            Assert.AreEqual(true, FhirReleaseParser.TryFhirReleaseFromMimeVersion("0.0", out version));
+            Assert.AreEqual(true, FhirReleaseParser.TryGetFhirReleaseFromMimeVersion("0.0", out version));
             Assert.AreEqual(FhirRelease.DSTU1, version);
-            Assert.AreEqual(true, FhirReleaseParser.TryFhirReleaseFromMimeVersion("1.0", out version));
+            Assert.AreEqual(true, FhirReleaseParser.TryGetFhirReleaseFromMimeVersion("1.0", out version));
             Assert.AreEqual(FhirRelease.DSTU2, version);
-            Assert.AreEqual(true, FhirReleaseParser.TryFhirReleaseFromMimeVersion("3.0", out version));
+            Assert.AreEqual(true, FhirReleaseParser.TryGetFhirReleaseFromMimeVersion("3.0", out version));
             Assert.AreEqual(FhirRelease.STU3, version);
-            Assert.AreEqual(true, FhirReleaseParser.TryFhirReleaseFromMimeVersion("4.0", out version));
+            Assert.AreEqual(true, FhirReleaseParser.TryGetFhirReleaseFromMimeVersion("4.0", out version));
             Assert.AreEqual(FhirRelease.R4, version);
-            Assert.AreEqual(true, FhirReleaseParser.TryFhirReleaseFromMimeVersion("5.0", out version));
+            Assert.AreEqual(true, FhirReleaseParser.TryGetFhirReleaseFromMimeVersion("5.0", out version));
             Assert.AreEqual(FhirRelease.R5, version);
 
-            Assert.AreEqual(false, FhirReleaseParser.TryFhirReleaseFromMimeVersion("0.0.0.0.1", out version));
+            Assert.AreEqual(false, FhirReleaseParser.TryGetFhirReleaseFromMimeVersion("0.0.0.0.1", out version));
             Assert.IsNull(version);
         }
 
@@ -120,15 +120,16 @@ namespace Hl7.Fhir.Utility.Tests
         public void TestTryFhirReleaseFromCorePackageName()
         {
             FhirRelease? version = null;
-            Assert.AreEqual(true, FhirReleaseParser.TryFhirReleaseFromCorePackageName("hl7.fhir.r3.core", out version));
+            Assert.AreEqual(true, FhirReleaseParser.TryGetFhirReleaseFromCorePackageName("hl7.fhir.r3.core", out version));
             Assert.AreEqual(FhirRelease.STU3, version);
-            Assert.AreEqual(true, FhirReleaseParser.TryFhirReleaseFromCorePackageName("hl7.fhir.r4.core", out version));
+            Assert.AreEqual(true, FhirReleaseParser.TryGetFhirReleaseFromCorePackageName("hl7.fhir.r4.core", out version));
             Assert.AreEqual(FhirRelease.R4, version);
-            Assert.AreEqual(true, FhirReleaseParser.TryFhirReleaseFromCorePackageName("hl7.fhir.r5.core", out version));
+            Assert.AreEqual(true, FhirReleaseParser.TryGetFhirReleaseFromCorePackageName("hl7.fhir.r5.core", out version));
             Assert.AreEqual(FhirRelease.R5, version);
 
-            Assert.AreEqual(false, FhirReleaseParser.TryFhirReleaseFromMimeVersion("hl7.fhir.core.r3", out version));
+            Assert.AreEqual(false, FhirReleaseParser.TryGetFhirReleaseFromCorePackageName("hl7.fhir.core.r3", out version));
             Assert.IsNull(version);
+
         }
 
 


### PR DESCRIPTION
fixes https://github.com/FirelyTeam/firely-net-sdk/issues/1655
TryGetFhirReleaseFromCorePackageName now returns correct result
also renamed methods and marked old ones as obsoleter