### PR TITLE
Support relative URLs on location headers when parsing HttpResponseMessage to EntryResponse

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Rest/HttpToEntryExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/HttpToEntryExtensions.cs
@@ -30,7 +30,7 @@ namespace Hl7.Fhir.Rest
                 Status = ((int)response.StatusCode).ToString(),
                 ResponseUri = response.RequestMessage.RequestUri,//this is actually the requestUri, can't find the responseUri
                 Body = body,
-                Location = response.Headers.Location?.AbsoluteUri ?? response.Content.Headers.ContentLocation?.AbsoluteUri,
+                Location = response.Headers.Location?.ToString() ?? response.Content.Headers.ContentLocation.ToString(),
                 LastModified = response.Content.Headers.LastModified,
                 Etag = response.Headers.ETag?.Tag.Trim('\"'),
                 ContentType = response.Content.Headers.ContentType?.MediaType

--- a/src/Hl7.Fhir.Support.Poco/Rest/HttpToEntryExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/HttpToEntryExtensions.cs
@@ -30,7 +30,7 @@ namespace Hl7.Fhir.Rest
                 Status = ((int)response.StatusCode).ToString(),
                 ResponseUri = response.RequestMessage.RequestUri,//this is actually the requestUri, can't find the responseUri
                 Body = body,
-                Location = response.Headers.Location?.ToString() ?? response.Content.Headers.ContentLocation.ToString(),
+                Location = response.Headers.Location?.ToString() ?? response.Content.Headers.ContentLocation?.ToString(),
                 LastModified = response.Content.Headers.LastModified,
                 Etag = response.Headers.ETag?.Tag.Trim('\"'),
                 ContentType = response.Content.Headers.ContentType?.MediaType

--- a/src/Hl7.Fhir.Support.Poco/Rest/HttpToEntryExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/HttpToEntryExtensions.cs
@@ -30,7 +30,7 @@ namespace Hl7.Fhir.Rest
                 Status = ((int)response.StatusCode).ToString(),
                 ResponseUri = response.RequestMessage.RequestUri,//this is actually the requestUri, can't find the responseUri
                 Body = body,
-                Location = response.Headers.Location?.ToString() ?? response.Content.Headers.ContentLocation?.ToString(),
+                Location = response.Headers.Location?.OriginalString ?? response.Content.Headers.ContentLocation?.OriginalString,
                 LastModified = response.Content.Headers.LastModified,
                 Etag = response.Headers.ETag?.Tag.Trim('\"'),
                 ContentType = response.Content.Headers.ContentType?.MediaType


### PR DESCRIPTION
fixes https://github.com/FirelyTeam/firely-net-sdk/issues/1659