### PR TITLE
Moved IncorrectElementDefinitionException to common.

### DIFF
--- a/src/Hl7.Fhir.ElementModel/Types/Any.cs
+++ b/src/Hl7.Fhir.ElementModel/Types/Any.cs
@@ -96,7 +96,7 @@ namespace Hl7.Fhir.ElementModel.Types
             }
         }
 
-        internal static (bool, T) DoConvert<T>(Func<T> parser)
+        internal static (bool, T?) DoConvert<T>(Func<T> parser)
         {
             try
             {
@@ -178,7 +178,7 @@ namespace Hl7.Fhir.ElementModel.Types
 
 
         protected static Result<T> propagateNull<T>(object obj, Func<T> a) => obj is null ?
-            (Result<T>)new Fail<T>(ArgNullException) : new Ok<T>(a());
+            new Fail<T>(ArgNullException) : new Ok<T>(a());
     }
 
 

--- a/src/Hl7.Fhir.Support.Tests/Serialization/PrimitiveTypeConverterTest.cs
+++ b/src/Hl7.Fhir.Support.Tests/Serialization/PrimitiveTypeConverterTest.cs
@@ -2,10 +2,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.Xml.Schema;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Hl7.Fhir.Support.Tests.Serialization
 {
@@ -19,10 +15,6 @@ namespace Hl7.Fhir.Support.Tests.Serialization
                 var result = PrimitiveTypeConverter.ConvertTo<T>(input);
                 Assert.IsNotNull(result);
                 Assert.AreEqual(expected, result, $"Input [{input}] was not expected [{expected.ToString()}]");
-            }
-            catch (AssertFailedException ae)
-            {
-                throw ae;
             }
             catch (Exception ex)
             {
@@ -50,7 +42,7 @@ namespace Hl7.Fhir.Support.Tests.Serialization
         private IEnumerable<(string input, DateTime expected, bool expectException)> GetDateTimeTestdata()
         {
             yield return ("0001-01-02+03:00", new DateTime(1, 1, 1, 21, 0, 0), false);
-            yield return ("0001-01-02T00:00:00+00:00", new DateTime(1, 1, 2, 0, 0, 0), false); 
+            yield return ("0001-01-02T00:00:00+00:00", new DateTime(1, 1, 2, 0, 0, 0), false);
             yield return ("2018-04-12T13:22:12Z", new DateTime(2018, 4, 12, 13, 22, 12), false);
             yield return ("2018-04-12T13:22:12+02:00", new DateTime(2018, 4, 12, 11, 22, 12), false);
             yield return ("2018-04-12+02:00", new DateTime(2018, 4, 11, 22, 0, 0), false);

--- a/src/Hl7.Fhir.Support/Validation/IncorrectElementDefinitionException.cs
+++ b/src/Hl7.Fhir.Support/Validation/IncorrectElementDefinitionException.cs
@@ -1,0 +1,23 @@
+﻿/* 
+ * Copyright (c) 2016, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using System;
+
+namespace Hl7.Fhir.Validation
+{
+    public class IncorrectElementDefinitionException : Exception
+    {
+        public IncorrectElementDefinitionException(string message) : base(message)
+        {
+        }
+
+        public IncorrectElementDefinitionException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
I am moving this type to common so it can be reused in the validator/compiler projects.

Also fixed compiler warnings.