### PR TITLE
Add backward compatibility to parse datetime for date fields

### DIFF
--- a/src/Hl7.Fhir.ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.ElementModel/TypedElementOnSourceNode.cs
@@ -199,6 +199,17 @@ namespace Hl7.Fhir.ElementModel
                     return val;
                 else
                 {
+                    if (_settings.AllowDateTimeInDate && ts == typeof(P.Date))
+                    {
+                        if (P.Any.TryParse(sourceText, typeof(P.DateTime), out var dateTimeVal))
+                        {
+                            // TruncateToDate converts 1991-02-03T11:22:33Z to 1991-02-03+00:00 which is not a valid date! 
+                            var date = (dateTimeVal as P.DateTime).TruncateToDate();
+                            // so we cut off timezone by converting it to timeoffset and cast back to date.
+                            return P.Date.FromDateTimeOffset(date.ToDateTimeOffset(0, 0, 0, TimeSpan.Zero));
+                        }
+                    }
+
                     raiseTypeError($"Literal '{sourceText}' cannot be parsed as a {InstanceType}.", _source, location: _source.Location);
                     return sourceText;
                 }

--- a/src/Hl7.Fhir.ElementModel/TypedElementSettings.cs
+++ b/src/Hl7.Fhir.ElementModel/TypedElementSettings.cs
@@ -39,6 +39,14 @@ namespace Hl7.Fhir.ElementModel
         /// </summary>
         public TypeErrorMode ErrorMode { get; set; } // = TypeErrorMode.Report;
 
+        /// <summary>
+        /// Allow to parse DateTime values in Date field.
+        /// </summary>
+        /// <remarks>
+        /// Needed for backward compatibility with old parser for resources which were saved and considered valid in the past.
+        /// </remarks>>
+        public bool AllowDateTimeInDate { get; set; }
+
         /// <summary>Default constructor. Creates a new <see cref="TypedElementSettings"/> instance with default property values.</summary>
         public TypedElementSettings() { }
 
@@ -58,6 +66,7 @@ namespace Hl7.Fhir.ElementModel
             if (other == null) throw Error.ArgumentNull(nameof(other));
 
             other.ErrorMode = ErrorMode;
+            other.AllowDateTimeInDate = AllowDateTimeInDate;
         }
 
         /// <summary>Creates a new <see cref="TypedElementSettings"/> object that is a copy of the current instance.</summary>

--- a/src/Hl7.Fhir.Support.Poco/ElementModel/PocoBuilder.cs
+++ b/src/Hl7.Fhir.Support.Poco/ElementModel/PocoBuilder.cs
@@ -77,7 +77,8 @@ namespace Hl7.Fhir.Serialization
             {
                 ErrorMode = _settings.IgnoreUnknownMembers ?
                     TypedElementSettings.TypeErrorMode.Ignore
-                    : TypedElementSettings.TypeErrorMode.Report
+                    : TypedElementSettings.TypeErrorMode.Report,
+                AllowDateTimeInDate = _settings.AllowDateTimeInDate
             };
 
             string dataType;

--- a/src/Hl7.Fhir.Support.Poco/ElementModel/PocoBuilderSettings.cs
+++ b/src/Hl7.Fhir.Support.Poco/ElementModel/PocoBuilderSettings.cs
@@ -26,6 +26,14 @@ namespace Hl7.Fhir.Serialization
         /// </summary>
         public bool IgnoreUnknownMembers { get; set; } // = false
 
+        /// <summary>
+        /// Allow to parse DateTime values in Date field.
+        /// </summary>
+        /// <remarks>
+        /// Needed for backward compatibility with old parser for resources which were saved and considered valid in the past.
+        /// </remarks>>
+        public bool AllowDateTimeInDate { get; set; }
+
         /// <summary>Default constructor. Creates a new <see cref="PocoBuilderSettings"/> instance with default property values.</summary>
         public PocoBuilderSettings() { }
 
@@ -46,6 +54,7 @@ namespace Hl7.Fhir.Serialization
 
             other.AllowUnrecognizedEnums = AllowUnrecognizedEnums;
             other.IgnoreUnknownMembers = IgnoreUnknownMembers;
+            other.AllowDateTimeInDate = AllowDateTimeInDate;
         }
 
         /// <summary>Creates a new <see cref="PocoBuilderSettings"/> object that is a copy of the current instance.</summary>

--- a/src/Hl7.Fhir.Support.Poco/Serialization/ParserSettings.cs
+++ b/src/Hl7.Fhir.Support.Poco/Serialization/ParserSettings.cs
@@ -38,6 +38,14 @@ namespace Hl7.Fhir.Serialization
         /// </summary>
         public bool PermissiveParsing { get; set; } = true;
 
+        /// <summary>
+        /// Allow to parse DateTime values in Date field.
+        /// </summary>
+        /// <remarks>
+        /// Needed for backward compatibility with old parser for resources which were saved and considered valid in the past.
+        /// </remarks>>
+        public bool AllowDateTimeInDate { get; set; } = false;
+
         /// <summary>Default constructor. Creates a new <see cref="ParserSettings"/> instance with default property values.</summary>
         public ParserSettings() { }
 
@@ -60,6 +68,7 @@ namespace Hl7.Fhir.Serialization
             other.AllowUnrecognizedEnums = AllowUnrecognizedEnums;
             other.AcceptUnknownMembers = AcceptUnknownMembers;
             other.PermissiveParsing = PermissiveParsing;
+            other.AllowDateTimeInDate = AllowDateTimeInDate;
         }
 
         /// <summary>
@@ -72,6 +81,7 @@ namespace Hl7.Fhir.Serialization
 
             settings.AllowUnrecognizedEnums = AllowUnrecognizedEnums;
             settings.IgnoreUnknownMembers = AcceptUnknownMembers;
+            settings.AllowDateTimeInDate = AllowDateTimeInDate;
         }
 
         /// <summary>Creates a new <see cref="ParserSettings"/> object that is a copy of the current instance.</summary>


### PR DESCRIPTION
see: https://github.com/FirelyTeam/firely-net-sdk/issues/1691
This is two part PR, second part would add `AllowDateTimeInDate` to `BaseFhirParser` class and also add tests for it. (gonna be in sdk repo)

