### PR TITLE
Async support Json/Xml Parsers + Serializers

### DIFF
--- a/src/Hl7.Fhir.Serialization/FhirJsonBuilderExtensions.cs
+++ b/src/Hl7.Fhir.Serialization/FhirJsonBuilderExtensions.cs
@@ -56,20 +56,20 @@ namespace Hl7.Fhir.Serialization
             => SerializationUtil.WriteJsonToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
         public static async Task<string> ToJsonAsync(this ITypedElement source, FhirJsonSerializationSettings settings = null)
-            => await SerializationUtil.WriteJsonToStringAsync(async writer => await source.WriteToAsync(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false).ConfigureAwait(false);
+            => await SerializationUtil.WriteJsonToStringAsync(async writer => await source.WriteToAsync(writer, settings).ConfigureAwait(false), settings?.Pretty ?? false, settings?.AppendNewLine ?? false).ConfigureAwait(false);
 
         /// <inheritdoc cref="ToJsonAsync(ISourceNode, FhirJsonSerializationSettings)" />
         public static string ToJson(this ISourceNode source, FhirJsonSerializationSettings settings = null)
             => SerializationUtil.WriteJsonToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
         public static async Task<string> ToJsonAsync(this ISourceNode source, FhirJsonSerializationSettings settings = null)
-            => await SerializationUtil.WriteJsonToStringAsync(async writer => await source.WriteToAsync(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false).ConfigureAwait(false);
+            => await SerializationUtil.WriteJsonToStringAsync(async writer => await source.WriteToAsync(writer, settings).ConfigureAwait(false), settings?.Pretty ?? false, settings?.AppendNewLine ?? false).ConfigureAwait(false);
 
         /// <inheritdoc cref="ToJsonBytesAsync(ITypedElement, FhirJsonSerializationSettings)" />
         public static byte[] ToJsonBytes(this ITypedElement source, FhirJsonSerializationSettings settings = null)
                 => SerializationUtil.WriteJsonToBytes(writer => source.WriteTo(writer, settings));
 
         public static async Task<byte[]> ToJsonBytesAsync(this ITypedElement source, FhirJsonSerializationSettings settings = null)
-                => await SerializationUtil.WriteJsonToBytesAsync(async writer => await source.WriteToAsync(writer, settings)).ConfigureAwait(false);
+                => await SerializationUtil.WriteJsonToBytesAsync(async writer => await source.WriteToAsync(writer, settings).ConfigureAwait(false)).ConfigureAwait(false);
     }
 }

--- a/src/Hl7.Fhir.Serialization/FhirJsonBuilderExtensions.cs
+++ b/src/Hl7.Fhir.Serialization/FhirJsonBuilderExtensions.cs
@@ -12,22 +12,41 @@ using Hl7.Fhir.Utility;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization
 {
     public static class FhirJsonBuilderExtensions
     {
+        /// <inheritdoc cref="writeToAsync(JObject, JsonWriter, string)" />
+        [Obsolete("Use writeToAsync(JObject, JsonWriter, string) instead.")]
         private static void writeTo(this JObject root, JsonWriter destination, string rootName = null)
         {
             root.WriteTo(destination);
             destination.Flush();
         }
 
+        private static async Task writeToAsync(this JObject root, JsonWriter destination, string rootName = null)
+        {
+            await root.WriteToAsync(destination);
+            await destination.FlushAsync();
+        }
+
+        /// <inheritdoc cref="WriteToAsync(ITypedElement, JsonWriter, FhirJsonSerializationSettings)" />
+        [Obsolete("Use WriteToAsync(ITypedElement, JsonWriter, FhirJsonSerializationSettings) instead.")]
         public static void WriteTo(this ITypedElement source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
             new FhirJsonBuilder(settings).Build(source).writeTo(destination);
 
+        public static async Task WriteToAsync(this ITypedElement source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
+            await new FhirJsonBuilder(settings).Build(source).writeToAsync(destination);
+
+        /// <inheritdoc cref="WriteToAsync(ISourceNode, JsonWriter, FhirJsonSerializationSettings)" />
+        [Obsolete("Use WriteToAsync(ISourceNode, JsonWriter, FhirJsonSerializationSettings) instead.")]
         public static void WriteTo(this ISourceNode source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
             new FhirJsonBuilder(settings).Build(source).writeTo(destination);
+
+        public static async Task WriteToAsync(this ISourceNode source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
+            await new FhirJsonBuilder(settings).Build(source).writeToAsync(destination);
 
         public static JObject ToJObject(this ISourceNode source, FhirJsonSerializationSettings settings = null) =>
             new FhirJsonBuilder(settings).Build(source);
@@ -35,13 +54,28 @@ namespace Hl7.Fhir.Serialization
         public static JObject ToJObject(this ITypedElement source, FhirJsonSerializationSettings settings = null) =>
             new FhirJsonBuilder(settings).Build(source);
 
+        /// <inheritdoc cref="ToJsonAsync(ITypedElement, FhirJsonSerializationSettings)" />
+        [Obsolete("Use ToJsonAsync(ITypedElement, FhirJsonSerializationSettings) instead.")]
         public static string ToJson(this ITypedElement source, FhirJsonSerializationSettings settings = null)
             => SerializationUtil.WriteJsonToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
+        public static async Task<string> ToJsonAsync(this ITypedElement source, FhirJsonSerializationSettings settings = null)
+            => await SerializationUtil.WriteJsonToStringAsync(async writer => await source.WriteToAsync(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
+
+        /// <inheritdoc cref="ToJsonAsync(ISourceNode, FhirJsonSerializationSettings)" />
+        [Obsolete("Use ToJsonAsync(ISourceNode, FhirJsonSerializationSettings) instead.")]
         public static string ToJson(this ISourceNode source, FhirJsonSerializationSettings settings = null)
             => SerializationUtil.WriteJsonToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
+        public static async Task<string> ToJsonAsync(this ISourceNode source, FhirJsonSerializationSettings settings = null)
+            => await SerializationUtil.WriteJsonToStringAsync(async writer => await source.WriteToAsync(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
+
+        /// <inheritdoc cref="ToJsonBytesAsync(ITypedElement, FhirJsonSerializationSettings)" />
+        [Obsolete("Use ToJsonBytesAsync(ITypedElement, FhirJsonSerializationSettings) instead.")]
         public static byte[] ToJsonBytes(this ITypedElement source, FhirJsonSerializationSettings settings = null)
                 => SerializationUtil.WriteJsonToBytes(writer => source.WriteTo(writer, settings));
+
+        public static async Task<byte[]> ToJsonBytesAsync(this ITypedElement source, FhirJsonSerializationSettings settings = null)
+                => await SerializationUtil.WriteJsonToBytesAsync(async writer => await source.WriteToAsync(writer, settings));
     }
 }

--- a/src/Hl7.Fhir.Serialization/FhirJsonBuilderExtensions.cs
+++ b/src/Hl7.Fhir.Serialization/FhirJsonBuilderExtensions.cs
@@ -19,7 +19,6 @@ namespace Hl7.Fhir.Serialization
     public static class FhirJsonBuilderExtensions
     {
         /// <inheritdoc cref="writeToAsync(JObject, JsonWriter, string)" />
-        [Obsolete("Use writeToAsync(JObject, JsonWriter, string) instead.")]
         private static void writeTo(this JObject root, JsonWriter destination, string rootName = null)
         {
             root.WriteTo(destination);
@@ -28,25 +27,23 @@ namespace Hl7.Fhir.Serialization
 
         private static async Task writeToAsync(this JObject root, JsonWriter destination, string rootName = null)
         {
-            await root.WriteToAsync(destination);
-            await destination.FlushAsync();
+            await root.WriteToAsync(destination).ConfigureAwait(false);
+            await destination.FlushAsync().ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="WriteToAsync(ITypedElement, JsonWriter, FhirJsonSerializationSettings)" />
-        [Obsolete("Use WriteToAsync(ITypedElement, JsonWriter, FhirJsonSerializationSettings) instead.")]
         public static void WriteTo(this ITypedElement source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
             new FhirJsonBuilder(settings).Build(source).writeTo(destination);
 
         public static async Task WriteToAsync(this ITypedElement source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
-            await new FhirJsonBuilder(settings).Build(source).writeToAsync(destination);
+            await new FhirJsonBuilder(settings).Build(source).writeToAsync(destination).ConfigureAwait(false);
 
         /// <inheritdoc cref="WriteToAsync(ISourceNode, JsonWriter, FhirJsonSerializationSettings)" />
-        [Obsolete("Use WriteToAsync(ISourceNode, JsonWriter, FhirJsonSerializationSettings) instead.")]
         public static void WriteTo(this ISourceNode source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
             new FhirJsonBuilder(settings).Build(source).writeTo(destination);
 
         public static async Task WriteToAsync(this ISourceNode source, JsonWriter destination, FhirJsonSerializationSettings settings = null) =>
-            await new FhirJsonBuilder(settings).Build(source).writeToAsync(destination);
+            await new FhirJsonBuilder(settings).Build(source).writeToAsync(destination).ConfigureAwait(false);
 
         public static JObject ToJObject(this ISourceNode source, FhirJsonSerializationSettings settings = null) =>
             new FhirJsonBuilder(settings).Build(source);
@@ -55,27 +52,24 @@ namespace Hl7.Fhir.Serialization
             new FhirJsonBuilder(settings).Build(source);
 
         /// <inheritdoc cref="ToJsonAsync(ITypedElement, FhirJsonSerializationSettings)" />
-        [Obsolete("Use ToJsonAsync(ITypedElement, FhirJsonSerializationSettings) instead.")]
         public static string ToJson(this ITypedElement source, FhirJsonSerializationSettings settings = null)
             => SerializationUtil.WriteJsonToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
         public static async Task<string> ToJsonAsync(this ITypedElement source, FhirJsonSerializationSettings settings = null)
-            => await SerializationUtil.WriteJsonToStringAsync(async writer => await source.WriteToAsync(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
+            => await SerializationUtil.WriteJsonToStringAsync(async writer => await source.WriteToAsync(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false).ConfigureAwait(false);
 
         /// <inheritdoc cref="ToJsonAsync(ISourceNode, FhirJsonSerializationSettings)" />
-        [Obsolete("Use ToJsonAsync(ISourceNode, FhirJsonSerializationSettings) instead.")]
         public static string ToJson(this ISourceNode source, FhirJsonSerializationSettings settings = null)
             => SerializationUtil.WriteJsonToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
         public static async Task<string> ToJsonAsync(this ISourceNode source, FhirJsonSerializationSettings settings = null)
-            => await SerializationUtil.WriteJsonToStringAsync(async writer => await source.WriteToAsync(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
+            => await SerializationUtil.WriteJsonToStringAsync(async writer => await source.WriteToAsync(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false).ConfigureAwait(false);
 
         /// <inheritdoc cref="ToJsonBytesAsync(ITypedElement, FhirJsonSerializationSettings)" />
-        [Obsolete("Use ToJsonBytesAsync(ITypedElement, FhirJsonSerializationSettings) instead.")]
         public static byte[] ToJsonBytes(this ITypedElement source, FhirJsonSerializationSettings settings = null)
                 => SerializationUtil.WriteJsonToBytes(writer => source.WriteTo(writer, settings));
 
         public static async Task<byte[]> ToJsonBytesAsync(this ITypedElement source, FhirJsonSerializationSettings settings = null)
-                => await SerializationUtil.WriteJsonToBytesAsync(async writer => await source.WriteToAsync(writer, settings));
+                => await SerializationUtil.WriteJsonToBytesAsync(async writer => await source.WriteToAsync(writer, settings)).ConfigureAwait(false);
     }
 }

--- a/src/Hl7.Fhir.Serialization/FhirJsonNodeFactory.cs
+++ b/src/Hl7.Fhir.Serialization/FhirJsonNodeFactory.cs
@@ -12,11 +12,14 @@ using Hl7.Fhir.Utility;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Threading.Tasks;
 
 namespace Hl7.Fhir.Serialization
 {
     public partial class FhirJsonNode
     {
+        /// <inheritdoc cref="ReadAsync(JsonReader, string, FhirJsonParsingSettings)" />
+        [Obsolete("Use ReadAsync(JsonReader, string, FhirJsonParsingSettings) instead.")]
         public static ISourceNode Read(JsonReader reader, string rootName = null, FhirJsonParsingSettings settings = null)
         {
             if (reader == null) throw Error.ArgumentNull(nameof(reader));
@@ -25,6 +28,16 @@ namespace Hl7.Fhir.Serialization
             return new FhirJsonNode(doc, rootName, settings);
         }
 
+        public static async Task<ISourceNode> ReadAsync(JsonReader reader, string rootName = null, FhirJsonParsingSettings settings = null)
+        {
+            if (reader == null) throw Error.ArgumentNull(nameof(reader));
+
+            var doc = await SerializationUtil.JObjectFromReaderAsync(reader).ConfigureAwait(false);
+            return new FhirJsonNode(doc, rootName, settings);
+        }
+
+        /// <inheritdoc cref="ParseAsync(string, string, FhirJsonParsingSettings)" />
+        [Obsolete("Use ParseAsync(string, string, FhirJsonParsingSettings) instead.")]
         public static ISourceNode Parse(string json, string rootName = null, FhirJsonParsingSettings settings = null)
         {
             if (json == null) throw Error.ArgumentNull(nameof(json));
@@ -32,6 +45,16 @@ namespace Hl7.Fhir.Serialization
             using (var reader = SerializationUtil.JsonReaderFromJsonText(json))
             {
                 return Read(reader, rootName, settings);
+            }
+        }
+
+        public static async Task<ISourceNode> ParseAsync(string json, string rootName = null, FhirJsonParsingSettings settings = null)
+        {
+            if (json == null) throw Error.ArgumentNull(nameof(json));
+
+            using (var reader = SerializationUtil.JsonReaderFromJsonText(json))
+            {
+                return await ReadAsync(reader, rootName, settings).ConfigureAwait(false);
             }
         }
 

--- a/src/Hl7.Fhir.Serialization/FhirJsonNodeFactory.cs
+++ b/src/Hl7.Fhir.Serialization/FhirJsonNodeFactory.cs
@@ -19,7 +19,6 @@ namespace Hl7.Fhir.Serialization
     public partial class FhirJsonNode
     {
         /// <inheritdoc cref="ReadAsync(JsonReader, string, FhirJsonParsingSettings)" />
-        [Obsolete("Use ReadAsync(JsonReader, string, FhirJsonParsingSettings) instead.")]
         public static ISourceNode Read(JsonReader reader, string rootName = null, FhirJsonParsingSettings settings = null)
         {
             if (reader == null) throw Error.ArgumentNull(nameof(reader));
@@ -37,7 +36,6 @@ namespace Hl7.Fhir.Serialization
         }
 
         /// <inheritdoc cref="ParseAsync(string, string, FhirJsonParsingSettings)" />
-        [Obsolete("Use ParseAsync(string, string, FhirJsonParsingSettings) instead.")]
         public static ISourceNode Parse(string json, string rootName = null, FhirJsonParsingSettings settings = null)
         {
             if (json == null) throw Error.ArgumentNull(nameof(json));

--- a/src/Hl7.Fhir.Serialization/FhirXmlBuilderExtensions.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlBuilderExtensions.cs
@@ -9,6 +9,8 @@
 
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Utility;
+using System;
+using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -16,6 +18,8 @@ namespace Hl7.Fhir.Serialization
 {
     public static class FhirXmlBuilderExtensions
     {
+        /// <inheritdoc cref="writeToAsync(XDocument, XmlWriter)" />
+        [Obsolete("Use writeToAsync(XDocument, XmlWriter) instead.")]
         private static void writeTo(this XDocument doc, XmlWriter destination)
         {
             if (doc.Root != null)
@@ -24,11 +28,29 @@ namespace Hl7.Fhir.Serialization
             destination.Flush();
         }
 
+        private static async Task writeToAsync(this XDocument doc, XmlWriter destination)
+        {
+            if (doc.Root != null)
+                doc.WriteTo(destination);
+
+            await destination.FlushAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc cref="WriteToAsync(ISourceNode, XmlWriter, FhirXmlSerializationSettings)" />
+        [Obsolete("Use WriteToAsync(ISourceNode, XmlWriter, FhirXmlSerializationSettings) instead.")]
         public static void WriteTo(this ISourceNode source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
             new FhirXmlBuilder(settings).Build(source).writeTo(destination);
 
+        public static async Task WriteToAsync(this ISourceNode source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
+            await new FhirXmlBuilder(settings).Build(source).writeToAsync(destination).ConfigureAwait(false);
+
+        /// <inheritdoc cref="WriteToAsync(ITypedElement, XmlWriter, FhirXmlSerializationSettings)" />
+        [Obsolete("Use WriteToAsync(ITypedElement, XmlWriter, FhirXmlSerializationSettings) instead.")]
         public static void WriteTo(this ITypedElement source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
             new FhirXmlBuilder(settings).Build(source).writeTo(destination);
+
+        public static async Task WriteToAsync(this ITypedElement source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
+            await new FhirXmlBuilder(settings).Build(source).writeToAsync(destination).ConfigureAwait(false);
 
         public static XDocument ToXDocument(this ISourceNode source, FhirXmlSerializationSettings settings = null) =>
             new FhirXmlBuilder(settings).Build(source);
@@ -36,13 +58,28 @@ namespace Hl7.Fhir.Serialization
         public static XDocument ToXDocument(this ITypedElement source, FhirXmlSerializationSettings settings = null) =>
             new FhirXmlBuilder(settings).Build(source);
 
+        /// <inheritdoc cref="ToXmlAsync(ISourceNode, FhirXmlSerializationSettings)" />
+        [Obsolete("Use ToXmlAsync(ISourceNode, FhirXmlSerializationSettings) instead.")]
         public static string ToXml(this ISourceNode source, FhirXmlSerializationSettings settings = null)
         => SerializationUtil.WriteXmlToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
+        public static async Task<string> ToXmlAsync(this ISourceNode source, FhirXmlSerializationSettings settings = null)
+                => await SerializationUtil.WriteXmlToStringAsync(async writer => await source.WriteToAsync(writer, settings).ConfigureAwait(false), settings?.Pretty ?? false, settings?.AppendNewLine ?? false).ConfigureAwait(false);
+
+        /// <inheritdoc cref="ToXmlAsync(ITypedElement, FhirXmlSerializationSettings)" />
+        [Obsolete("Use ToXmlAsync(ITypedElement, FhirXmlSerializationSettings) instead.")]
         public static string ToXml(this ITypedElement source, FhirXmlSerializationSettings settings = null)
                 => SerializationUtil.WriteXmlToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
+        public static async Task<string> ToXmlAsync(this ITypedElement source, FhirXmlSerializationSettings settings = null)
+                => await SerializationUtil.WriteXmlToStringAsync(async writer => await source.WriteToAsync(writer, settings).ConfigureAwait(false), settings?.Pretty ?? false, settings?.AppendNewLine ?? false).ConfigureAwait(false);
+
+        /// <inheritdoc cref="ToXmlBytesAsync(ITypedElement, FhirXmlSerializationSettings)" />
+        [Obsolete("Use ToXmlBytesAsync(ITypedElement, FhirXmlSerializationSettings) instead.")]
         public static byte[] ToXmlBytes(this ITypedElement source, FhirXmlSerializationSettings settings = null)
                 => SerializationUtil.WriteXmlToBytes(writer => source.WriteTo(writer, settings));
+
+        public static async Task<byte[]> ToXmlBytesAsync(this ITypedElement source, FhirXmlSerializationSettings settings = null)
+                => await SerializationUtil.WriteXmlToBytesAsync(async writer => await source.WriteToAsync(writer, settings).ConfigureAwait(false)).ConfigureAwait(false);
     }
 }

--- a/src/Hl7.Fhir.Serialization/FhirXmlBuilderExtensions.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace Hl7.Fhir.Serialization
 
         /// <inheritdoc cref="WriteToAsync(ISourceNode, XmlWriter, FhirXmlSerializationSettings)" />
         public static void WriteTo(this ISourceNode source, XmlWriter destination, FhirXmlSerializationSettings settings = null) => 
-            TaskHelper.Await(() => WriteToAsync(source, destination, settings));
+            new FhirXmlBuilder(settings).Build(source).writeTo(destination);
 
         public static async Task WriteToAsync(this ISourceNode source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
             await new FhirXmlBuilder(settings).Build(source).writeToAsync(destination).ConfigureAwait(false);

--- a/src/Hl7.Fhir.Serialization/FhirXmlBuilderExtensions.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlBuilderExtensions.cs
@@ -10,6 +10,7 @@
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Utility;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
@@ -19,7 +20,6 @@ namespace Hl7.Fhir.Serialization
     public static class FhirXmlBuilderExtensions
     {
         /// <inheritdoc cref="writeToAsync(XDocument, XmlWriter)" />
-        [Obsolete("Use writeToAsync(XDocument, XmlWriter) instead.")]
         private static void writeTo(this XDocument doc, XmlWriter destination)
         {
             if (doc.Root != null)
@@ -37,15 +37,13 @@ namespace Hl7.Fhir.Serialization
         }
 
         /// <inheritdoc cref="WriteToAsync(ISourceNode, XmlWriter, FhirXmlSerializationSettings)" />
-        [Obsolete("Use WriteToAsync(ISourceNode, XmlWriter, FhirXmlSerializationSettings) instead.")]
-        public static void WriteTo(this ISourceNode source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
-            new FhirXmlBuilder(settings).Build(source).writeTo(destination);
+        public static void WriteTo(this ISourceNode source, XmlWriter destination, FhirXmlSerializationSettings settings = null) => 
+            TaskHelper.Await(() => WriteToAsync(source, destination, settings));
 
         public static async Task WriteToAsync(this ISourceNode source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
             await new FhirXmlBuilder(settings).Build(source).writeToAsync(destination).ConfigureAwait(false);
 
         /// <inheritdoc cref="WriteToAsync(ITypedElement, XmlWriter, FhirXmlSerializationSettings)" />
-        [Obsolete("Use WriteToAsync(ITypedElement, XmlWriter, FhirXmlSerializationSettings) instead.")]
         public static void WriteTo(this ITypedElement source, XmlWriter destination, FhirXmlSerializationSettings settings = null) =>
             new FhirXmlBuilder(settings).Build(source).writeTo(destination);
 
@@ -59,27 +57,24 @@ namespace Hl7.Fhir.Serialization
             new FhirXmlBuilder(settings).Build(source);
 
         /// <inheritdoc cref="ToXmlAsync(ISourceNode, FhirXmlSerializationSettings)" />
-        [Obsolete("Use ToXmlAsync(ISourceNode, FhirXmlSerializationSettings) instead.")]
         public static string ToXml(this ISourceNode source, FhirXmlSerializationSettings settings = null)
         => SerializationUtil.WriteXmlToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
         public static async Task<string> ToXmlAsync(this ISourceNode source, FhirXmlSerializationSettings settings = null)
-                => await SerializationUtil.WriteXmlToStringAsync(async writer => await source.WriteToAsync(writer, settings).ConfigureAwait(false), settings?.Pretty ?? false, settings?.AppendNewLine ?? false).ConfigureAwait(false);
+            => await SerializationUtil.WriteXmlToStringAsync(async writer => await source.WriteToAsync(writer, settings).ConfigureAwait(false), settings?.Pretty ?? false, settings?.AppendNewLine ?? false).ConfigureAwait(false);
 
         /// <inheritdoc cref="ToXmlAsync(ITypedElement, FhirXmlSerializationSettings)" />
-        [Obsolete("Use ToXmlAsync(ITypedElement, FhirXmlSerializationSettings) instead.")]
         public static string ToXml(this ITypedElement source, FhirXmlSerializationSettings settings = null)
                 => SerializationUtil.WriteXmlToString(writer => source.WriteTo(writer, settings), settings?.Pretty ?? false, settings?.AppendNewLine ?? false);
 
         public static async Task<string> ToXmlAsync(this ITypedElement source, FhirXmlSerializationSettings settings = null)
-                => await SerializationUtil.WriteXmlToStringAsync(async writer => await source.WriteToAsync(writer, settings).ConfigureAwait(false), settings?.Pretty ?? false, settings?.AppendNewLine ?? false).ConfigureAwait(false);
+            => await SerializationUtil.WriteXmlToStringAsync(async writer => await source.WriteToAsync(writer, settings).ConfigureAwait(false), settings?.Pretty ?? false, settings?.AppendNewLine ?? false).ConfigureAwait(false);
 
         /// <inheritdoc cref="ToXmlBytesAsync(ITypedElement, FhirXmlSerializationSettings)" />
-        [Obsolete("Use ToXmlBytesAsync(ITypedElement, FhirXmlSerializationSettings) instead.")]
         public static byte[] ToXmlBytes(this ITypedElement source, FhirXmlSerializationSettings settings = null)
                 => SerializationUtil.WriteXmlToBytes(writer => source.WriteTo(writer, settings));
 
         public static async Task<byte[]> ToXmlBytesAsync(this ITypedElement source, FhirXmlSerializationSettings settings = null)
-                => await SerializationUtil.WriteXmlToBytesAsync(async writer => await source.WriteToAsync(writer, settings).ConfigureAwait(false)).ConfigureAwait(false);
+            => await SerializationUtil.WriteXmlToBytesAsync(async writer => await source.WriteToAsync(writer, settings).ConfigureAwait(false)).ConfigureAwait(false);
     }
 }

--- a/src/Hl7.Fhir.Serialization/FhirXmlNodeFactory.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlNodeFactory.cs
@@ -7,9 +7,8 @@
  */
 
 using Hl7.Fhir.ElementModel;
-using Hl7.Fhir.Specification;
 using Hl7.Fhir.Utility;
-using System;
+using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -17,6 +16,7 @@ namespace Hl7.Fhir.Serialization
 {
     public partial class FhirXmlNode
     {
+        /// <inheritdoc cref="ReadAsync(XmlReader, FhirXmlParsingSettings)" />
         public static ISourceNode Read(XmlReader reader, FhirXmlParsingSettings settings = null)
         {
             if (reader == null) throw Error.ArgumentNull(nameof(reader));
@@ -24,7 +24,16 @@ namespace Hl7.Fhir.Serialization
             var doc = SerializationUtil.XDocumentFromReader(reader, ignoreComments: false);
             return new FhirXmlNode(doc.Root, settings);
         }
+        
+        public static async Task<ISourceNode> ReadAsync(XmlReader reader, FhirXmlParsingSettings settings = null)
+        {
+            if (reader == null) throw Error.ArgumentNull(nameof(reader));
 
+            var doc = await SerializationUtil.XDocumentFromReaderAsync(reader, ignoreComments: false).ConfigureAwait(false);
+            return new FhirXmlNode(doc.Root, settings);
+        }
+
+        /// <inheritdoc cref="ParseAsync(string, FhirXmlParsingSettings)" />
         public static ISourceNode Parse(string xml, FhirXmlParsingSettings settings = null)
         {
             if (xml == null) throw Error.ArgumentNull(nameof(xml));
@@ -32,6 +41,16 @@ namespace Hl7.Fhir.Serialization
             using (var reader = SerializationUtil.XmlReaderFromXmlText(xml, ignoreComments: false))
             {
                 return Read(reader, settings);
+            }
+        }
+        
+        public static async Task<ISourceNode> ParseAsync(string xml, FhirXmlParsingSettings settings = null)
+        {
+            if (xml == null) throw Error.ArgumentNull(nameof(xml));
+
+            using (var reader = await SerializationUtil.XmlReaderFromXmlTextAsync(xml, ignoreComments: false))
+            {
+                return await ReadAsync(reader, settings).ConfigureAwait(false);
             }
         }
 

--- a/src/Hl7.Fhir.Serialization/Utility/SerializationUtil.cs
+++ b/src/Hl7.Fhir.Serialization/Utility/SerializationUtil.cs
@@ -51,6 +51,9 @@ namespace Hl7.Fhir.Utility
 
         public static XDocument XDocumentFromReader(XmlReader reader, bool ignoreComments = true)
             => XDocumentFromReaderInternal(WrapXmlReader(reader, ignoreComments));
+        
+        public static Task<XDocument> XDocumentFromReaderAsync(XmlReader reader, bool ignoreComments = true)
+            => Task.FromResult(XDocumentFromReaderInternal(WrapXmlReader(reader, ignoreComments, async:true)));
 
         /// <inheritdoc cref="JObjectFromReaderAsync(JsonReader)" />
         public static JObject JObjectFromReader(JsonReader reader)
@@ -122,6 +125,9 @@ namespace Hl7.Fhir.Utility
 
         public static XmlReader XmlReaderFromXmlText(string xml, bool ignoreComments = true)
             => WrapXmlReader(XmlReader.Create(new StringReader(SerializationUtil.SanitizeXml(xml))), ignoreComments);
+        
+        public static Task<XmlReader> XmlReaderFromXmlTextAsync(string xml, bool ignoreComments = true)
+            => Task.FromResult(WrapXmlReader(XmlReader.Create(new StringReader(SerializationUtil.SanitizeXml(xml))), ignoreComments, async:true));
 
         public static JsonReader JsonReaderFromJsonText(string json)
             => JsonReaderFromTextReader(new StringReader(json));
@@ -143,7 +149,7 @@ namespace Hl7.Fhir.Utility
         }
 
 
-        public static XmlReader WrapXmlReader(XmlReader xmlReader, bool ignoreComments = true)
+        public static XmlReader WrapXmlReader(XmlReader xmlReader, bool ignoreComments = true, bool async = false)
         {
             var settings = new XmlReaderSettings
             {
@@ -151,6 +157,7 @@ namespace Hl7.Fhir.Utility
                 IgnoreProcessingInstructions = true,
                 IgnoreWhitespace = true,
                 DtdProcessing = DtdProcessing.Prohibit,
+                Async = async,
             };
 
             return XmlReader.Create(xmlReader, settings);

--- a/src/Hl7.Fhir.Serialization/Utility/SerializationUtil.cs
+++ b/src/Hl7.Fhir.Serialization/Utility/SerializationUtil.cs
@@ -270,7 +270,7 @@ namespace Hl7.Fhir.Utility
             using (XmlWriter xw = doc.CreateWriter())
             {
                 await serializer(xw).ConfigureAwait(false);
-                await xw.FlushAsync();
+                await xw.FlushAsync().ConfigureAwait(false);
             }
 
             return doc;

--- a/src/Hl7.Fhir.Serialization/Utility/SerializationUtil.cs
+++ b/src/Hl7.Fhir.Serialization/Utility/SerializationUtil.cs
@@ -249,6 +249,7 @@ namespace Hl7.Fhir.Utility
             }
         }
 
+        /// <inheritdoc cref="WriteXmlToDocumentAsync(Func{XmlWriter, Task})" />
         public static XDocument WriteXmlToDocument(Action<XmlWriter> serializer)
         {
             var doc = new XDocument();
@@ -257,6 +258,19 @@ namespace Hl7.Fhir.Utility
             {
                 serializer(xw);
                 xw.Flush();
+            }
+
+            return doc;
+        }
+        
+        public static async Task<XDocument> WriteXmlToDocumentAsync(Func<XmlWriter, Task> serializer)
+        {
+            var doc = new XDocument();
+
+            using (XmlWriter xw = doc.CreateWriter())
+            {
+                await serializer(xw).ConfigureAwait(false);
+                await xw.FlushAsync();
             }
 
             return doc;

--- a/src/Hl7.Fhir.Support.Poco/Rest/EntryToTypedElementExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/EntryToTypedElementExtensions.cs
@@ -10,7 +10,6 @@ namespace Hl7.Fhir.Rest
     public static class EntryToTypedEntryExtensions
     {
         /// <inheritdoc cref="ToTypedEntryResponseAsync(EntryResponse, IStructureDefinitionSummaryProvider)" />
-        [Obsolete("Use ToTypedEntryResponseAsync(EntryResponse, IStructureDefinitionSummaryProvider) instead.")]
         public static TypedEntryResponse ToTypedEntryResponse(this EntryResponse response, IStructureDefinitionSummaryProvider provider)
             => TaskHelper.Await(() => ToTypedEntryResponseAsync(response, provider));
 

--- a/src/Hl7.Fhir.Support.Poco/Rest/EntryToTypedElementExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/EntryToTypedElementExtensions.cs
@@ -56,7 +56,7 @@ namespace Hl7.Fhir.Rest
             {
                return (fhirType == ResourceFormat.Json)
                     ? (await FhirJsonNode.ParseAsync(bodyText).ConfigureAwait(false)).ToTypedElement(provider)
-                    : FhirXmlNode.Parse(bodyText).ToTypedElement(provider);
+                    : (await FhirXmlNode.ParseAsync(bodyText).ConfigureAwait(false)).ToTypedElement(provider);
             }
             catch (FormatException) when (!throwOnFormatException)
             {           

--- a/src/Hl7.Fhir.Support.Tests/JsonAssert.cs
+++ b/src/Hl7.Fhir.Support.Tests/JsonAssert.cs
@@ -19,10 +19,8 @@ namespace Hl7.Fhir.Tests
     {
         public static void AreSame(string filename, string expected, string actual, List<string> errors)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             var exp = SerializationUtil.JObjectFromJsonText(expected);
             var act = SerializationUtil.JObjectFromJsonText(actual);
-#pragma warning restore CS0618 // Type or member is obsolete
 
             AreSame(filename, exp, act, errors);
         }

--- a/src/Hl7.Fhir.Support.Tests/JsonAssert.cs
+++ b/src/Hl7.Fhir.Support.Tests/JsonAssert.cs
@@ -19,8 +19,10 @@ namespace Hl7.Fhir.Tests
     {
         public static void AreSame(string filename, string expected, string actual, List<string> errors)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var exp = SerializationUtil.JObjectFromJsonText(expected);
             var act = SerializationUtil.JObjectFromJsonText(actual);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             AreSame(filename, exp, act, errors);
         }


### PR DESCRIPTION
Async support for Json Parsers related and Json/Xml Serializers

Non-async methods marked as obsolete, documentation refers to the corresponding Async method

Corresponding PR https://github.com/FirelyTeam/firely-net-sdk/pull/1700