### PR TITLE
FhirPath: 'as' operator can return FHIR primtives

### DIFF
--- a/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTableInit.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTableInit.cs
@@ -179,7 +179,7 @@ namespace Hl7.FhirPath.Expressions
 
             t.Add("ofType", (IEnumerable<ITypedElement> f, string name) => f.FilterType(name), doNullProp: true);
             t.Add("binary.is", (object f, ITypedElement left, string name) => left.Is(name), doNullProp: true);
-            t.Add("binary.as", (object f, ITypedElement left, string name) => left.CastAs(name), doNullProp: true);
+            t.Add("binary.as", (object f, IEnumerable<ITypedElement> left, string name) => left.FilterType(name), doNullProp: true);
 
             // Kept for backwards compatibility, but no longer part of the spec
             t.Add("binary.as", (object f, IEnumerable<ITypedElement> left, string name) => left.FilterType(name), doNullProp: true);


### PR DESCRIPTION
The 'as' operator would return a 'string' instead of 'uri'.
This fix should be considered a workaround and not a fix for the
underlying issue which probably will need a refactor of the delgate
Invokee and methods in Invokee.cs
Fixes: https://github.com/FirelyTeam/firely-net-sdk/issues/1643