### PR TITLE
Add the "canonical" url to the FhirTypeAttribute

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Introspection/ClassMapping.cs
+++ b/src/Hl7.Fhir.Support.Poco/Introspection/ClassMapping.cs
@@ -84,6 +84,12 @@ namespace Hl7.Fhir.Introspection
         /// </summary>
         public bool IsNestedType { get; private set; } = false;
 
+        /// <summary>
+        /// The canonical for the StructureDefinition defining this type
+        /// </summary>
+        /// <remarks>Will be null for backbone types.</remarks>
+        public string? Canonical { get; private set; }
+
         private class PropertyMappingCollection
         {
             public PropertyMappingCollection()
@@ -216,7 +222,8 @@ namespace Hl7.Fhir.Introspection
                 IsCodeOfT = ReflectionHelper.IsClosedGenericType(type) &&
                                 ReflectionHelper.IsConstructedFromGenericTypeDefinition(type, typeof(Code<>)),
                 IsNestedType = typeAttribute.IsNestedType,
-                _mappingInitializer = () => inspectProperties(type, fhirVersion)
+                _mappingInitializer = () => inspectProperties(type, fhirVersion),
+                Canonical = typeAttribute.Canonical
             };
 
             return true;
@@ -263,7 +270,7 @@ namespace Hl7.Fhir.Introspection
             if (ReflectionHelper.IsClosedGenericType(type))
             {
                 name += "<";
-                name += String.Join(",", type.GetTypeInfo().GenericTypeArguments.Select(arg => arg.FullName));
+                name += string.Join(",", type.GetTypeInfo().GenericTypeArguments.Select(arg => arg.FullName));
                 name += ">";
             }
 

--- a/src/Hl7.Fhir.Support.Poco/Introspection/FhirTypeAttribute.cs
+++ b/src/Hl7.Fhir.Support.Poco/Introspection/FhirTypeAttribute.cs
@@ -44,6 +44,12 @@ namespace Hl7.Fhir.Introspection
             Name = name ?? throw new ArgumentNullException(nameof(name));
         }
 
+        public FhirTypeAttribute(string name, string canonical)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Canonical = canonical;
+        }
+
         /// <summary>
         /// The name of the FHIR type this class represents.
         /// </summary>
@@ -58,5 +64,10 @@ namespace Hl7.Fhir.Introspection
         /// Indicates whether this class represents a Resource
         /// </summary>
         public bool IsResource { get; set; }
+
+        /// <summary>
+        /// The canonical of the StructureDefinition defining this type.
+        /// </summary>
+        public string Canonical { get; set; }
     }
 }

--- a/src/Hl7.Fhir.Support.Poco/Model/Base.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Base.cs
@@ -39,7 +39,7 @@ using System.Runtime.Serialization;
 namespace Hl7.Fhir.Model
 {
     [Serializable]
-    [FhirType("Base")]
+    [FhirType("Base", "http://hl7.org/fhir/StructureDefinition/Base")]
     [DataContract]
     public abstract class Base : Validation.IValidatableObject, IDeepCopyable, IDeepComparable, IAnnotated, IAnnotatable, INotifyPropertyChanged
     {
@@ -89,7 +89,7 @@ namespace Hl7.Fhir.Model
         #region << Annotations >>
         [NonSerialized]
         private readonly Lazy<AnnotationList> _annotations = new Lazy<AnnotationList>(() => new AnnotationList());
-        
+
         private AnnotationList annotations { get { return _annotations.Value; } }
 
         public IEnumerable<object> Annotations(Type type) => annotations.OfType(type);

--- a/src/Hl7.Fhir.Support.Poco/Model/Element.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Element.cs
@@ -42,7 +42,7 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [Serializable]
     [DataContract]
-    [FhirType("Element")]
+    [FhirType("Element", "http://hl7.org/fhir/StructureDefinition/Element")]
     public abstract class Element : Base, IExtendable
     {
         /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Extension.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Extension.cs
@@ -44,7 +44,7 @@ namespace Hl7.Fhir.Model
     /// </summary>
     [Serializable]
     [System.Diagnostics.DebuggerDisplay(@"\{Value={Value} Url={_Url}}")]
-    [FhirType("Extension")]
+    [FhirType("Extension", "http://hl7.org/fhir/StructureDefinition/Extension")]
     [DataContract]
     public class Extension : DataType
     {

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/BackboneElement.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/BackboneElement.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("BackboneElement")]
+  [FhirType("BackboneElement","http://hl7.org/fhir/StructureDefinition/BackboneElement")]
   public abstract partial class BackboneElement : Hl7.Fhir.Model.Element, Hl7.Fhir.Model.IModifierExtendable
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/BackboneType.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/BackboneType.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("BackboneType")]
+  [FhirType("BackboneType","http://hl7.org/fhir/StructureDefinition/BackboneType")]
   public abstract partial class BackboneType : Hl7.Fhir.Model.DataType, Hl7.Fhir.Model.IModifierExtendable
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Base64Binary.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Base64Binary.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("base64Binary")]
+  [FhirType("base64Binary","http://hl7.org/fhir/StructureDefinition/base64Binary")]
   public partial class Base64Binary : PrimitiveType, IValue<byte[]>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Canonical.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Canonical.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("canonical")]
+  [FhirType("canonical","http://hl7.org/fhir/StructureDefinition/canonical")]
   public partial class Canonical : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Code.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Code.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("code")]
+  [FhirType("code","http://hl7.org/fhir/StructureDefinition/code")]
   public partial class Code : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/CodeableConcept.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/CodeableConcept.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("CodeableConcept")]
+  [FhirType("CodeableConcept","http://hl7.org/fhir/StructureDefinition/CodeableConcept")]
   public partial class CodeableConcept : Hl7.Fhir.Model.DataType
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Coding.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Coding.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("Coding")]
+  [FhirType("Coding","http://hl7.org/fhir/StructureDefinition/Coding")]
   public partial class Coding : Hl7.Fhir.Model.DataType
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/ContactDetail.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/ContactDetail.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("ContactDetail")]
+  [FhirType("ContactDetail","http://hl7.org/fhir/StructureDefinition/ContactDetail")]
   public partial class ContactDetail : Hl7.Fhir.Model.DataType
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/ContactPoint.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/ContactPoint.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("ContactPoint")]
+  [FhirType("ContactPoint","http://hl7.org/fhir/StructureDefinition/ContactPoint")]
   public partial class ContactPoint : Hl7.Fhir.Model.DataType
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/DataType.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/DataType.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("DataType")]
+  [FhirType("DataType","http://hl7.org/fhir/StructureDefinition/DataType")]
   public abstract partial class DataType : Hl7.Fhir.Model.Element
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Date.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Date.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("date")]
+  [FhirType("date","http://hl7.org/fhir/StructureDefinition/date")]
   public partial class Date : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/DomainResource.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/DomainResource.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("DomainResource", IsResource=true)]
+  [FhirType("DomainResource","http://hl7.org/fhir/StructureDefinition/DomainResource", IsResource=true)]
   public abstract partial class DomainResource : Hl7.Fhir.Model.Resource, Hl7.Fhir.Model.IModifierExtendable
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/FhirBoolean.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/FhirBoolean.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("boolean")]
+  [FhirType("boolean","http://hl7.org/fhir/StructureDefinition/boolean")]
   public partial class FhirBoolean : PrimitiveType, INullableValue<bool>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/FhirDateTime.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/FhirDateTime.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("dateTime")]
+  [FhirType("dateTime","http://hl7.org/fhir/StructureDefinition/dateTime")]
   public partial class FhirDateTime : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/FhirDecimal.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/FhirDecimal.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("decimal")]
+  [FhirType("decimal","http://hl7.org/fhir/StructureDefinition/decimal")]
   public partial class FhirDecimal : PrimitiveType, INullableValue<decimal>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/FhirString.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/FhirString.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("string")]
+  [FhirType("string","http://hl7.org/fhir/StructureDefinition/string")]
   public partial class FhirString : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/FhirUri.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/FhirUri.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("uri")]
+  [FhirType("uri","http://hl7.org/fhir/StructureDefinition/uri")]
   public partial class FhirUri : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/FhirUrl.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/FhirUrl.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("url")]
+  [FhirType("url","http://hl7.org/fhir/StructureDefinition/url")]
   public partial class FhirUrl : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Id.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Id.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("id")]
+  [FhirType("id","http://hl7.org/fhir/StructureDefinition/id")]
   public partial class Id : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Identifier.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Identifier.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("Identifier")]
+  [FhirType("Identifier","http://hl7.org/fhir/StructureDefinition/Identifier")]
   public partial class Identifier : Hl7.Fhir.Model.DataType
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Instant.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Instant.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("instant")]
+  [FhirType("instant","http://hl7.org/fhir/StructureDefinition/instant")]
   public partial class Instant : PrimitiveType, INullableValue<DateTimeOffset>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Integer.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Integer.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("integer")]
+  [FhirType("integer","http://hl7.org/fhir/StructureDefinition/integer")]
   public partial class Integer : PrimitiveType, INullableValue<int>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Integer64.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Integer64.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("integer64")]
+  [FhirType("integer64","http://hl7.org/fhir/StructureDefinition/integer64")]
   public partial class Integer64 : PrimitiveType, INullableValue<long>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Markdown.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Markdown.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("markdown")]
+  [FhirType("markdown","http://hl7.org/fhir/StructureDefinition/markdown")]
   public partial class Markdown : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Meta.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Meta.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("Meta")]
+  [FhirType("Meta","http://hl7.org/fhir/StructureDefinition/Meta")]
   public partial class Meta : Hl7.Fhir.Model.DataType
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Oid.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Oid.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("oid")]
+  [FhirType("oid","http://hl7.org/fhir/StructureDefinition/oid")]
   public partial class Oid : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/OperationOutcome.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/OperationOutcome.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("OperationOutcome", IsResource=true)]
+  [FhirType("OperationOutcome","http://hl7.org/fhir/StructureDefinition/OperationOutcome", IsResource=true)]
   public partial class OperationOutcome : Hl7.Fhir.Model.DomainResource
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Parameters.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Parameters.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("Parameters", IsResource=true)]
+  [FhirType("Parameters","http://hl7.org/fhir/StructureDefinition/Parameters", IsResource=true)]
   public partial class Parameters : Hl7.Fhir.Model.Resource
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Period.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Period.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("Period")]
+  [FhirType("Period","http://hl7.org/fhir/StructureDefinition/Period")]
   public partial class Period : Hl7.Fhir.Model.DataType
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/PositiveInt.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/PositiveInt.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("positiveInt")]
+  [FhirType("positiveInt","http://hl7.org/fhir/StructureDefinition/positiveInt")]
   public partial class PositiveInt : PrimitiveType, INullableValue<int>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Quantity.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Quantity.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("Quantity")]
+  [FhirType("Quantity","http://hl7.org/fhir/StructureDefinition/Quantity")]
   public partial class Quantity : Hl7.Fhir.Model.DataType
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Range.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Range.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("Range")]
+  [FhirType("Range","http://hl7.org/fhir/StructureDefinition/Range")]
   public partial class Range : Hl7.Fhir.Model.DataType
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Resource.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Resource.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("Resource", IsResource=true)]
+  [FhirType("Resource","http://hl7.org/fhir/StructureDefinition/Resource", IsResource=true)]
   public abstract partial class Resource : Hl7.Fhir.Model.Base
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/ResourceReference.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/ResourceReference.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("Reference")]
+  [FhirType("Reference","http://hl7.org/fhir/StructureDefinition/Reference")]
   public partial class ResourceReference : Hl7.Fhir.Model.DataType
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Time.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Time.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("time")]
+  [FhirType("time","http://hl7.org/fhir/StructureDefinition/time")]
   public partial class Time : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/UnsignedInt.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/UnsignedInt.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("unsignedInt")]
+  [FhirType("unsignedInt","http://hl7.org/fhir/StructureDefinition/unsignedInt")]
   public partial class UnsignedInt : PrimitiveType, INullableValue<int>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/UsageContext.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/UsageContext.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   /// </summary>
   [Serializable]
   [DataContract]
-  [FhirType("UsageContext")]
+  [FhirType("UsageContext","http://hl7.org/fhir/StructureDefinition/UsageContext")]
   public partial class UsageContext : Hl7.Fhir.Model.DataType
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/Uuid.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/Uuid.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("uuid")]
+  [FhirType("uuid","http://hl7.org/fhir/StructureDefinition/uuid")]
   public partial class Uuid : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Generated/XHtml.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Generated/XHtml.cs
@@ -47,7 +47,7 @@ namespace Hl7.Fhir.Model
   [System.Diagnostics.DebuggerDisplay(@"\{Value={Value}}")]
   [Serializable]
   [DataContract]
-  [FhirType("xhtml")]
+  [FhirType("xhtml","http://hl7.org/fhir/StructureDefinition/xhtml")]
   public partial class XHtml : PrimitiveType, IValue<string>
   {
     /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Model/Narrative.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Narrative.cs
@@ -43,7 +43,7 @@ namespace Hl7.Fhir.Model
     /// Human-readable summary of the resource (essential clinical and business information)
     /// </summary>
     [Serializable]
-    [FhirType("Narrative")]
+    [FhirType("Narrative", "http://hl7.org/fhir/StructureDefinition/Narrative")]
     [DataContract]
     public class Narrative : Hl7.Fhir.Model.DataType
     {

--- a/src/Hl7.Fhir.Support.Poco/Model/PrimitiveType.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/PrimitiveType.cs
@@ -17,7 +17,7 @@ using System.Runtime.Serialization;
 namespace Hl7.Fhir.Model
 {
     [Serializable]
-    [FhirType("PrimitiveType")]
+    [FhirType("PrimitiveType", "http://hl7.org/fhir/StructureDefinition/PrimitiveType")]
     [DataContract]
     public abstract class PrimitiveType : DataType
     {


### PR DESCRIPTION
Adds canonical url information to the FHIR metadata on the POCOs so we can look up metadata by canonical.