### PR TITLE
FHIR Specific variables %rootResource and %resource are set correctly now

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/FhirPath/FhirEvaluationContext.cs
+++ b/src/Hl7.Fhir.Support.Poco/FhirPath/FhirEvaluationContext.cs
@@ -32,6 +32,14 @@ namespace Hl7.Fhir.FhirPath
         {
         }
 
+        public FhirEvaluationContext(ScopedNode resource)
+            : base(toNearestParentResource(resource))
+        {
+            RootResource = Resource is ScopedNode node ? node.ResourceContext : resource;
+        }
+
+        private static ScopedNode toNearestParentResource(ScopedNode node) => node.AtResource ? node : node.ParentResource;
+
         private Func<string, ITypedElement> _elementResolver;
 
         public Func<string, ITypedElement> ElementResolver

--- a/src/Hl7.Fhir.Support.Poco/FhirPath/FhirEvaluationContext.cs
+++ b/src/Hl7.Fhir.Support.Poco/FhirPath/FhirEvaluationContext.cs
@@ -33,12 +33,12 @@ namespace Hl7.Fhir.FhirPath
         }
 
         public FhirEvaluationContext(ScopedNode resource)
-            : base(toNearestParentResource(resource))
+            : this(toNearestParentResource(resource))
         {
             RootResource = Resource is ScopedNode node ? node.ResourceContext : resource;
         }
 
-        private static ScopedNode toNearestParentResource(ScopedNode node) => node.AtResource ? node : node.ParentResource;
+        private static ITypedElement toNearestParentResource(ScopedNode node) => node.AtResource ? node : node.ResourceContext;
 
         private Func<string, ITypedElement> _elementResolver;
 

--- a/src/Hl7.Fhir.Support.Poco/FhirPath/FhirEvaluationContext.cs
+++ b/src/Hl7.Fhir.Support.Poco/FhirPath/FhirEvaluationContext.cs
@@ -32,13 +32,27 @@ namespace Hl7.Fhir.FhirPath
         {
         }
 
-        public FhirEvaluationContext(ScopedNode resource)
-            : this(toNearestParentResource(resource))
+        /// <summary>
+        /// Create a FhirEvaluationContext and also set the variables <c>%resource</c> and <c>%rootResource</c> to their correct values.
+        /// </summary>
+        /// <param name="node">input for determining the variables <c>%resource</c> and <c>%rootResource</c></param>
+        public FhirEvaluationContext(ScopedNode node)
+            : this(toNearestResource(node))
         {
-            RootResource = Resource is ScopedNode node ? node.ResourceContext : resource;
+            RootResource = Resource is ScopedNode sn ? sn.ResourceContext : node;
         }
 
-        private static ITypedElement toNearestParentResource(ScopedNode node) => node.AtResource ? node : node.ResourceContext;
+        private static ITypedElement toNearestResource(ScopedNode node)
+        {
+            var scan = node;
+
+            while (scan.AtResource == false && scan.ParentResource is not null)
+            {
+                scan = scan.ParentResource;
+            }
+
+            return scan;
+        }
 
         private Func<string, ITypedElement> _elementResolver;
 

--- a/src/Hl7.FhirPath/FhirPath/EvaluationContext.cs
+++ b/src/Hl7.FhirPath/FhirPath/EvaluationContext.cs
@@ -26,10 +26,8 @@ namespace Hl7.FhirPath
         /// <param name="rootResource">The data that will be represented by <c>%rootResource</c>.</param>
         public EvaluationContext(ITypedElement resource, ITypedElement rootResource)
         {
-            Resource = (resource is ScopedNode sn) ? toNearestParentResource(sn) : resource;
-            RootResource = (rootResource is null && Resource is ScopedNode node) ? node.ResourceContext : resource;
-
-            static ITypedElement toNearestParentResource(ScopedNode node) => node.AtResource ? node : node.ParentResource;
+            Resource = resource;
+            RootResource = rootResource ?? resource;
         }
 
         /// <summary>

--- a/src/Hl7.FhirPath/FhirPath/EvaluationContext.cs
+++ b/src/Hl7.FhirPath/FhirPath/EvaluationContext.cs
@@ -26,8 +26,10 @@ namespace Hl7.FhirPath
         /// <param name="rootResource">The data that will be represented by <c>%rootResource</c>.</param>
         public EvaluationContext(ITypedElement resource, ITypedElement rootResource)
         {
-            Resource = resource;
-            RootResource = rootResource ?? resource;
+            Resource = (resource is ScopedNode sn) ? toNearestParentResource(sn) : resource;
+            RootResource = (rootResource is null && Resource is ScopedNode node) ? node.ResourceContext : resource;
+
+            static ITypedElement toNearestParentResource(ScopedNode node) => node.AtResource ? node : node.ParentResource;
         }
 
         /// <summary>


### PR DESCRIPTION
FHIR Specific variables `%rootResource` and `%resource` are now set correctly. See also the assumptions in https://github.com/FirelyTeam/firely-net-sdk/issues/1742#issuecomment-875598124.

Resolves FirelyTeam/firely-net-sdk#1742