### PR TITLE
Suppress warning CS1591 (Missing XML comments) in Release mode

### DIFF
--- a/src/firely-net-common.props
+++ b/src/firely-net-common.props
@@ -50,7 +50,8 @@
     <AssemblyOriginatorKeyFile>..\FhirNetApi.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>True</IncludeSymbols>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	  <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <NoWarn>1591</NoWarn>    <!-- Missing XML comments -->
   </PropertyGroup>  
 </Project>
 


### PR DESCRIPTION
## Description
Suppress warning CS1591 (Missing XML comments) in Release mode. It flooded the warnings in Azure Devops, in such a way that we do not see important warnings anymore.

