### PR TITLE
Return correct match when parsing similar polymorphic elements in a single resource [Common]

### DIFF
--- a/src/Hl7.Fhir.ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.ElementModel/TypedElementOnSourceNode.cs
@@ -340,11 +340,12 @@ namespace Hl7.Fhir.ElementModel
             if (dis.TryGetValue(name, out info))
                 return true;
 
-            // Now, check the choice elements for a match
-            // (this should actually be the longest match, but that's kind of expensive,
-            // so as long as we don't add stupid ambiguous choices to a single type, this will work.
-            info = dis.Where(kvp => name.StartsWith(kvp.Key) && kvp.Value.IsChoiceElement)
-                .Select(kvp => kvp.Value).FirstOrDefault();
+            // Now, check the choice elements for a match          
+            var matches = dis.Where(kvp => name.StartsWith(kvp.Key) && kvp.Value.IsChoiceElement);
+
+            // this will loop over all matches and return the longest match.
+            if (matches.Any())
+             info = matches.Aggregate((l, r) => l.Key.Length > r.Key.Length ? l : r).Value;               
 
             return info != null;
         }

--- a/src/Hl7.Fhir.ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.ElementModel/TypedElementOnSourceNode.cs
@@ -341,13 +341,20 @@ namespace Hl7.Fhir.ElementModel
                 return true;
 
             // Now, check the choice elements for a match          
-            var matches = dis.Where(kvp => name.StartsWith(kvp.Key) && kvp.Value.IsChoiceElement);
+            var matches = dis.Where(kvp => name.StartsWith(kvp.Key) && kvp.Value.IsChoiceElement).ToList();
 
             // this will loop over all matches and return the longest match.
             if (matches.Any())
-             info = matches.Aggregate((l, r) => l.Key.Length > r.Key.Length ? l : r).Value;               
-
-            return info != null;
+            {
+                info = (matches.Count == 1)
+                        ? matches[0].Value 
+                        : matches.Aggregate((l, r) => l.Key.Length > r.Key.Length ? l : r).Value;
+                return true;
+            }          
+            else
+            {
+                return false;
+            }          
         }
 
         private IEnumerable<TypedElementOnSourceNode> enumerateElements(Dictionary<string, IElementDefinitionSummary> dis, ISourceNode parent, string name)


### PR DESCRIPTION
fixes https://github.com/FirelyTeam/firely-net-sdk/issues/1858