### PR TITLE
Do not allow FhirPath navigating with ChoiceTypes that include a type, like `valueString`.

### DIFF
--- a/src/Hl7.Fhir.ElementModel/TypedElementOnSourceNode.cs
+++ b/src/Hl7.Fhir.ElementModel/TypedElementOnSourceNode.cs
@@ -347,14 +347,14 @@ namespace Hl7.Fhir.ElementModel
             if (matches.Any())
             {
                 info = (matches.Count == 1)
-                        ? matches[0].Value 
+                        ? matches[0].Value
                         : matches.Aggregate((l, r) => l.Key.Length > r.Key.Length ? l : r).Value;
                 return true;
-            }          
+            }
             else
             {
                 return false;
-            }          
+            }
         }
 
         private IEnumerable<TypedElementOnSourceNode> enumerateElements(Dictionary<string, IElementDefinitionSummary> dis, ISourceNode parent, string name)
@@ -366,10 +366,10 @@ namespace Hl7.Fhir.ElementModel
                 childSet = parent.Children();
             else
             {
-                var hit = tryGetBySuffixedName(dis, name, out var info);
-                childSet = hit && info.IsChoiceElement ?
-                    parent.Children(name + "*") :
-                    parent.Children(name);
+                var hit = dis.TryGetValue(name, out var info);
+                childSet = hit
+                    ? (info.IsChoiceElement ? parent.Children(name + "*") : parent.Children(name))
+                    : Enumerable.Empty<ISourceNode>();
             }
 
             string lastName = null;

--- a/src/Hl7.Fhir.Support.Tests/FhirPath/FhirPathTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/FhirPath/FhirPathTests.cs
@@ -15,6 +15,7 @@ using Hl7.Fhir.Serialization;
 using Hl7.FhirPath;
 using Hl7.FhirPath.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Hl7.Fhir.Support.Tests
@@ -45,9 +46,9 @@ namespace Hl7.Fhir.Support.Tests
 
         [DataTestMethod]
         [DataRow("<div>Not empty</div>", false, "no XHTML namespace")]
-        [DataRow("<div xmlns=\"http://www.w3.org/1999/xhtml\"> </div>", false, "containing only whitespace")] 
-        [DataRow("<div xmlns=\"http://www.w3.org/1999/xhtml\">\t\n</div>", false, "containing only whitespace")] 
-        [DataRow("<div xmlns=\"http://www.w3.org/1999/xhtml\"></div>", false, "empty div element")] 
+        [DataRow("<div xmlns=\"http://www.w3.org/1999/xhtml\"> </div>", false, "containing only whitespace")]
+        [DataRow("<div xmlns=\"http://www.w3.org/1999/xhtml\">\t\n</div>", false, "containing only whitespace")]
+        [DataRow("<div xmlns=\"http://www.w3.org/1999/xhtml\"></div>", false, "empty div element")]
         [DataRow("<div xmlns=\"http://www.w3.org/1999/xhtml\">Not empty</div>", true, "non empty div element with XHTML namespace")]
         [DataRow("<div xmlns=\"http://www.w3.org/1999/xhtml\"><img src=\"fhir.gif\" alt=\"Fhir gif\"></img></div>", true, "containing an image element")]
         [DataRow("<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b><i> </i></b></p></div>", false, "no text")]
@@ -57,19 +58,28 @@ namespace Hl7.Fhir.Support.Tests
             var evaluator = _compiler.Compile("htmlChecks()");
             evaluator.Predicate(ElementNode.ForPrimitive(xml), FhirEvaluationContext.CreateDefault()).Should().Be(expected, because);
         }
-        
-        [TestMethod]
-        public void NavigateWithChoiceTypes()
-        {
-            var xml = "<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"item\" /><valueString value=\"test\"/></parameter></Parameters>";
-            var sourceNode = FhirXmlNode.Parse(xml);
-            var typedElement = sourceNode.ToTypedElement(ModelInspector.ForAssembly(typeof(Resource).Assembly));
 
+        [DataTestMethod]
+        [DynamicData(nameof(GetTypedElements), DynamicDataSourceType.Method)]
+        public void NavigateWithChoiceTypes(ITypedElement typedElement, string method)
+        {
             // expression with TypedElement
             typedElement.Predicate("parameter[0].value.exists()").Should().BeTrue();
             typedElement.Predicate("parameter[0].valueString.exists()").Should().BeFalse();
             typedElement.Scalar("parameter[0].value").Should().Be("test");
             typedElement.Scalar("parameter[0].valueString").Should().BeNull();
+        }
+
+        public static IEnumerable<object[]> GetTypedElements()
+        {
+            var xml = "<Parameters xmlns=\"http://hl7.org/fhir\"><parameter><name value=\"item\" /><valueString value=\"test\"/></parameter></Parameters>";
+            var sourceNode = FhirXmlNode.Parse(xml);
+
+            yield return new object[] { sourceNode.ToTypedElement(ModelInspector.ForAssembly(typeof(Resource).Assembly)), "sourceNode to TypedElement" };
+
+            var poco = TypedSerialization.ToPoco<Parameters>(sourceNode);
+            yield return new object[] { TypedSerialization.ToTypedElement(poco), "poco to TypedElement" };
+
         }
     }
 }

--- a/src/Hl7.FhirPath/FhirPath/Functions/CollectionOperators.cs
+++ b/src/Hl7.FhirPath/FhirPath/Functions/CollectionOperators.cs
@@ -82,10 +82,7 @@ namespace Hl7.FhirPath.Functions
                 }
             }
 
-            return filter(element.Children(name), name);
-
-            static IEnumerable<ITypedElement> filter(IEnumerable<ITypedElement> children, string name) =>
-                name == null ? children : children.Where(c => c.Name == name);
+            return element.Children(name);
         }
 
         public static string FpJoin(this IEnumerable<ITypedElement> collection, string separator)


### PR DESCRIPTION
Fixes FirelyTeam/firely-net-sdk#1785