### PR TITLE
SymbolTable is more threadsafe now

### DIFF
--- a/src/Hl7.FhirPath.Tests/Tests/SymbolTableTests.cs
+++ b/src/Hl7.FhirPath.Tests/Tests/SymbolTableTests.cs
@@ -1,0 +1,45 @@
+﻿using Hl7.Fhir.ElementModel;
+using Hl7.FhirPath;
+using Hl7.FhirPath.Expressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Threading.Tasks;
+
+namespace HL7.FhirPath.Tests.Tests
+{
+    [TestClass]
+    public class SymbolTableTests
+    {
+        [TestMethod]
+        public void SymbolTableUsedByMultipleThreads()
+        {
+            // setup multiple tasks
+            Task[] taskArray = new Task[10];
+            for (int i = 0; i < taskArray.Length; i++)
+            {
+                taskArray[i] = new Task(compile);
+            }
+
+            // execute the tasks in parallel
+            try
+            {
+                Parallel.ForEach<Task>(taskArray, (t) => { t.Start(); });
+                Task.WaitAll(taskArray);
+
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message + " " + ex.StackTrace);
+            }
+
+            void compile()
+            {
+                var compiler = new FhirPathCompiler();
+                compiler.Symbols.Add<ITypedElement, bool, string, EvaluationContext, ITypedElement>("noOp", NoOp);
+                compiler.Compile("(CapabilityStatement.useContext.value as Quantity) | (CapabilityStatement.useContext.value as Range)");
+
+                static ITypedElement NoOp(ITypedElement elem, bool condition, string message, EvaluationContext ctx) => elem;
+            }
+        }
+    }
+}

--- a/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTable.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTable.cs
@@ -6,10 +6,11 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
  */
 
-using System;
-using System.Linq;
-using System.Collections.Generic;
 using Hl7.Fhir.ElementModel;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Hl7.FhirPath.Expressions
@@ -86,7 +87,7 @@ namespace Hl7.FhirPath.Expressions
             }
         }
 
-        private List<TableEntry> _entries = new List<TableEntry>();
+        private ConcurrentBag<TableEntry> _entries = new();
 
         internal void Add(CallSignature signature, Invokee body)
         {
@@ -96,7 +97,7 @@ namespace Hl7.FhirPath.Expressions
         public SymbolTable Filter(string name, int argCount)
         {
             var result = new SymbolTable();
-            result._entries = new List<TableEntry>(_entries.Where(e => e.Signature.Matches(name, argCount)));
+            result._entries = new(_entries.Where(e => e.Signature.Matches(name, argCount)));
 
             if (Parent != null)
                 result.Parent = Parent.Filter(name, argCount);
@@ -116,21 +117,21 @@ namespace Hl7.FhirPath.Expressions
 
 
     public static class SymbolTableExtensions
-    {    
+    {
         public static void Add<R>(this SymbolTable table, string name, Func<R> func)
         {
             table.Add(new CallSignature(name, typeof(R)), InvokeeFactory.Wrap(func));
         }
 
-        public static void Add<A,R>(this SymbolTable table, string name, Func<A,R> func, bool doNullProp = false)
+        public static void Add<A, R>(this SymbolTable table, string name, Func<A, R> func, bool doNullProp = false)
         {
-            if(typeof(A) != typeof(EvaluationContext))
+            if (typeof(A) != typeof(EvaluationContext))
                 table.Add(new CallSignature(name, typeof(R), typeof(A)), InvokeeFactory.Wrap(func, doNullProp));
             else
                 table.Add(new CallSignature(name, typeof(R)), InvokeeFactory.Wrap(func, doNullProp));
         }
 
-        public static void Add<A,B,R>(this SymbolTable table, string name, Func<A,B,R> func, bool doNullProp = false)
+        public static void Add<A, B, R>(this SymbolTable table, string name, Func<A, B, R> func, bool doNullProp = false)
         {
             if (typeof(B) != typeof(EvaluationContext))
                 table.Add(new CallSignature(name, typeof(R), typeof(A), typeof(B)), InvokeeFactory.Wrap(func, doNullProp));
@@ -138,7 +139,7 @@ namespace Hl7.FhirPath.Expressions
                 table.Add(new CallSignature(name, typeof(R), typeof(A)), InvokeeFactory.Wrap(func, doNullProp));
         }
 
-        public static void Add<A, B, C, R>(this SymbolTable table, string name, Func<A, B,C, R> func, bool doNullProp = false)
+        public static void Add<A, B, C, R>(this SymbolTable table, string name, Func<A, B, C, R> func, bool doNullProp = false)
         {
             if (typeof(C) != typeof(EvaluationContext))
                 table.Add(new CallSignature(name, typeof(R), typeof(A), typeof(B), typeof(C)), InvokeeFactory.Wrap(func, doNullProp));
@@ -146,7 +147,7 @@ namespace Hl7.FhirPath.Expressions
                 table.Add(new CallSignature(name, typeof(R), typeof(A), typeof(B)), InvokeeFactory.Wrap(func, doNullProp));
         }
 
-        public static void Add<A, B, C, D, R>(this SymbolTable table, string name, Func<A,B,C,D,R> func, bool doNullProp = false)
+        public static void Add<A, B, C, D, R>(this SymbolTable table, string name, Func<A, B, C, D, R> func, bool doNullProp = false)
         {
             if (typeof(D) != typeof(EvaluationContext))
                 table.Add(new CallSignature(name, typeof(R), typeof(A), typeof(B), typeof(C), typeof(D)), InvokeeFactory.Wrap(func, doNullProp));


### PR DESCRIPTION
Resolves FirelyTeam/firely-net-sdk#1884.

The entries of the SymbolTable are now hold by a `ConcurrentBag<>` instead of a `List<>`. That makes the `SymbolTable` more threadsafe.