### PR TITLE
Remove netstandard1.6 from the TargetFrameworks

### DIFF
--- a/src/Hl7.Fhir.ElementModel/Hl7.Fhir.ElementModel.csproj
+++ b/src/Hl7.Fhir.ElementModel/Hl7.Fhir.ElementModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net452;netstandard1.6;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net5.0;net452;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<Import Project="..\firely-net-common.props" />
@@ -15,7 +15,7 @@
 		<AssemblyName>Hl7.Fhir.ElementModel</AssemblyName>
 	</PropertyGroup>
 	
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net452' or '$(TargetFramework)' == 'netstandard1.6'">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net452'">
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 

--- a/src/Hl7.Fhir.ElementModel/Types/String.cs
+++ b/src/Hl7.Fhir.ElementModel/Types/String.cs
@@ -53,16 +53,11 @@ namespace Hl7.Fhir.ElementModel.Types
             var l = comparisonType.HasFlag(StringComparison.NormalizeWhitespace) ? normalizeWS(Value) : Value;
             var r = comparisonType.HasFlag(StringComparison.NormalizeWhitespace) ? normalizeWS(otherS.Value) : otherS.Value;
 
-#if !NETSTANDARD1_6
             var compareOptions = CompareOptions.None;
             if (comparisonType.HasFlag(StringComparison.IgnoreCase)) compareOptions |= CompareOptions.IgnoreCase;
             if (comparisonType.HasFlag(StringComparison.IgnoreDiacritics)) compareOptions |= CompareOptions.IgnoreNonSpace;
 
             return string.Compare(l, r, CultureInfo.InvariantCulture, compareOptions) == 0;
-#else
-            return string.Compare(l, r, comparisonType.HasFlag(StringComparison.IgnoreCase) ?
-                System.StringComparison.OrdinalIgnoreCase : System.StringComparison.Ordinal) == 0;
-#endif
         }
 
         public const StringComparison CQL_EQUALS_COMPARISON = StringComparison.Unicode;

--- a/src/Hl7.Fhir.Serialization/FhirJsonNode.cs
+++ b/src/Hl7.Fhir.Serialization/FhirJsonNode.cs
@@ -365,7 +365,6 @@ namespace Hl7.Fhir.Serialization
         {
             yield return checkArrayUse;
 
-#if !NETSTANDARD1_6
             yield return checkXhtml;
 
             object checkXhtml(ITypedElement nav, IExceptionSource ies, object _)
@@ -394,7 +393,6 @@ namespace Hl7.Fhir.Serialization
                 }
                 return null;
             }
-#endif
 
             object checkArrayUse(ITypedElement nav, IExceptionSource ies, object _)
             {

--- a/src/Hl7.Fhir.Serialization/FhirJsonParsingSettings.cs
+++ b/src/Hl7.Fhir.Serialization/FhirJsonParsingSettings.cs
@@ -25,13 +25,11 @@ namespace Hl7.Fhir.Serialization
         /// </summary>
         public bool AllowJsonComments { get; set; } // = false;
 
-#if !NETSTANDARD1_6
         /// <summary>
         /// Validate narrative against the FHIR Xhtml schema.
         /// </summary>
         /// <remarks>Validation of xhtml is expensive, so turned off by default.</remarks>
         public bool ValidateFhirXhtml { get; set; } // = false;
-#endif
 
         /// <summary>Default constructor. Creates a new <see cref="FhirJsonParsingSettings"/> instance with default property values.</summary>
         public FhirJsonParsingSettings() { }
@@ -53,10 +51,7 @@ namespace Hl7.Fhir.Serialization
 
             other.PermissiveParsing = PermissiveParsing;
             other.AllowJsonComments = AllowJsonComments;
-
-#if !NETSTANDARD1_6
             other.ValidateFhirXhtml = ValidateFhirXhtml;
-#endif
         }
 
         /// <summary>Creates a new <see cref="FhirJsonParsingSettings"/> object that is a copy of the current instance.</summary>

--- a/src/Hl7.Fhir.Serialization/FhirXmlNode.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlNode.cs
@@ -45,10 +45,7 @@ namespace Hl7.Fhir.Serialization
         public XNamespace[] AllowedExternalNamespaces => _settings.AllowedExternalNamespaces;
         public bool DisallowSchemaLocation => _settings.DisallowSchemaLocation;
         public bool PermissiveParsing => _settings.PermissiveParsing;
-
-#if !NETSTANDARD1_6
         public bool ValidateFhirXhtml => _settings.ValidateFhirXhtml;
-#endif
 
         private XElement _containedResource;
 
@@ -134,10 +131,8 @@ namespace Hl7.Fhir.Serialization
             // don't move into xhtml
             if (Current.AtXhtmlDiv())
             {
-#if !NETSTANDARD1_6
                 if (!PermissiveParsing && ValidateFhirXhtml)
                     ValidateXhtml(new XDocument(Current), this, this);
-#endif
                 yield break;
             }
 
@@ -294,13 +289,6 @@ namespace Hl7.Fhir.Serialization
                 return Enumerable.Empty<object>();
         }
 
-#if !NETSTANDARD1_6
-        //public static void ValidateXhtml(string xmlText, IExceptionSource ies, object source)
-        //{
-        //    reportOnValidation(() =>
-        //       SerializationUtil.RunFhirXhtmlSchemaValidation(xmlText), ies, source);
-        //}
-
         public static void ValidateXhtml(XDocument doc, IExceptionSource ies, object source)
         {
             // TODO: When this is moved out of FhirXmlNode to a later validation phase,
@@ -317,7 +305,6 @@ namespace Hl7.Fhir.Serialization
                         Error.Format("Parser: Encountered narrative with incorrect Xhtml. Xsd validation reported: " + problems)));
             }
         }
-#endif
 
         private static void raiseFormatError(object source, IExceptionSource ies, string message, XObject position)
         {

--- a/src/Hl7.Fhir.Serialization/FhirXmlParsingSettings.cs
+++ b/src/Hl7.Fhir.Serialization/FhirXmlParsingSettings.cs
@@ -31,13 +31,12 @@ namespace Hl7.Fhir.Serialization
         /// </summary>
         public bool PermissiveParsing { get; set; } = true;
 
-#if !NETSTANDARD1_6
         /// <summary>
         /// Validate narrative against the FHIR Xhtml schema.
         /// </summary>
         /// <remarks>Validation of xhtml is expensive, so turned off by default.</remarks>
         public bool ValidateFhirXhtml { get; set; } // = false;
-#endif
+
         /// <summary>Default constructor. Creates a new <see cref="FhirXmlParsingSettings"/> instance with default property values.</summary>
         public FhirXmlParsingSettings() { }
 
@@ -59,10 +58,7 @@ namespace Hl7.Fhir.Serialization
             other.AllowedExternalNamespaces = (XNamespace[])AllowedExternalNamespaces?.Clone();
             other.DisallowSchemaLocation = DisallowSchemaLocation;
             other.PermissiveParsing = PermissiveParsing;
-
-#if !NETSTANDARD1_6
             other.ValidateFhirXhtml = ValidateFhirXhtml;
-#endif
         }
 
         /// <summary>Creates a new <see cref="FhirXmlParsingSettings"/> object that is a copy of the current instance.</summary>

--- a/src/Hl7.Fhir.Serialization/Hl7.Fhir.Serialization.csproj
+++ b/src/Hl7.Fhir.Serialization/Hl7.Fhir.Serialization.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net452;netstandard1.6;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net5.0;net452;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<Import Project="..\firely-net-common.props" />

--- a/src/Hl7.Fhir.Serialization/Utility/SerializationUtil.cs
+++ b/src/Hl7.Fhir.Serialization/Utility/SerializationUtil.cs
@@ -18,10 +18,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
-
-#if !NETSTANDARD1_6
 using System.Xml.Schema;
-#endif
 
 namespace Hl7.Fhir.Utility
 {
@@ -452,7 +449,6 @@ namespace Hl7.Fhir.Utility
             return resultRE;
         }
 
-#if !NETSTANDARD1_6
         public static string[] RunFhirXhtmlSchemaValidation(string xmlText)
         {
             try
@@ -522,8 +518,6 @@ namespace Hl7.Fhir.Utility
                 }
             }
         }
-#endif
-
 
         private static Regex _re = new Regex("(&[a-zA-Z0-9]+;)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
         private static Dictionary<string, string> _xmlReplacements;

--- a/src/Hl7.Fhir.Support.Poco/Hl7.Fhir.Support.Poco.csproj
+++ b/src/Hl7.Fhir.Support.Poco/Hl7.Fhir.Support.Poco.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net452;netstandard1.6;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net5.0;net452;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<Import Project="..\firely-net-common.props" />
@@ -25,10 +25,6 @@
     <Reference Include="System.Net.Http"/>
   </ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-		<PackageReference Include="System.Net.Requests" Version="4.3.0" />
-	</ItemGroup>
-	
 	<ItemGroup>
 		<ProjectReference Include="..\Hl7.Fhir.ElementModel\Hl7.Fhir.ElementModel.csproj" />
 		<ProjectReference Include="..\Hl7.Fhir.Support\Hl7.Fhir.Support.csproj" />

--- a/src/Hl7.Fhir.Support.Poco/Model/XHtml.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/XHtml.cs
@@ -35,11 +35,6 @@ namespace Hl7.Fhir.Model
 {
     public partial class XHtml
     {
-#if NETSTANDARD1_6
-        public static bool IsValidValue(string _) => true;
-#else
         public static bool IsValidValue(string value) => !SerializationUtil.RunFhirXhtmlSchemaValidation(value).Any();
-#endif
-
     }
 }

--- a/src/Hl7.Fhir.Support.Poco/Rest/ContentType.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/ContentType.cs
@@ -143,10 +143,6 @@ namespace Hl7.Fhir.Rest
 
         public static string GetMediaTypeFromHeaderValue(string mediaHeaderValue)
         {
-#if NETSTANDARD1_6
-            System.Net.Http.Headers.MediaTypeHeaderValue.TryParse(mediaHeaderValue, out System.Net.Http.Headers.MediaTypeHeaderValue headerValue);
-            return headerValue != null ? headerValue.MediaType.ToLowerInvariant() : mediaHeaderValue;
-#else
             try
             {
                 var ct = new System.Net.Mime.ContentType(mediaHeaderValue);
@@ -156,18 +152,12 @@ namespace Hl7.Fhir.Rest
             {
                 return mediaHeaderValue;
             }
-#endif
         }
 
         public static string GetCharSetFromHeaderValue(string mediaHeaderValue)
         {
-#if NETSTANDARD1_6
-            System.Net.Http.Headers.MediaTypeHeaderValue.TryParse(mediaHeaderValue, out System.Net.Http.Headers.MediaTypeHeaderValue headerValue);
-            return headerValue.CharSet;
-#else
             var ct = new System.Net.Mime.ContentType(mediaHeaderValue);
             return ct.CharSet;
-#endif
         }
     }
 }

--- a/src/Hl7.Fhir.Support.Poco/Rest/EntryToHttpExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/EntryToHttpExtensions.cs
@@ -148,12 +148,7 @@ namespace Hl7.Fhir.Rest
 
             if (entry.Headers.IfMatch != null) request.Headers["If-Match"] = entry.Headers.IfMatch;
             if (entry.Headers.IfNoneMatch != null) request.Headers["If-None-Match"] = entry.Headers.IfNoneMatch;
-#if NETSTANDARD1_6
-            if (entry.Headers.IfModifiedSince != null) request.Headers["If-Modified-Since"] = entry.Headers.IfModifiedSince.Value.UtcDateTime.ToString();
-#else
             if (entry.Headers.IfModifiedSince != null) request.IfModifiedSince = entry.Headers.IfModifiedSince.Value.UtcDateTime;
-
-#endif
             if (entry.Headers.IfNoneExist != null) request.Headers["If-None-Exist"] = entry.Headers.IfNoneExist;
 
             if (canHaveReturnPreference() && settings.PreferredReturn.HasValue)
@@ -180,10 +175,8 @@ namespace Hl7.Fhir.Rest
                  entry.Type == InteractionType.Patch;
 
             // PCL doesn't support setting the length (and in this case will be empty anyway)
-#if !NETSTANDARD1_6
             if (entry.RequestBodyContent == null)
                 request.ContentLength = 0;
-#endif
             return request;
         }
 
@@ -217,11 +210,7 @@ namespace Hl7.Fhir.Rest
                 // platform does not support UserAgent property...too bad
                 try
                 {
-#if NETSTANDARD1_6
-                    request.Headers[HttpRequestHeader.UserAgent] = agent;
-#else
                     request.UserAgent = agent;
-#endif
                 }
                 catch (ArgumentException)
                 {

--- a/src/Hl7.Fhir.Support.Poco/Rest/HttpToEntryExtensions.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/HttpToEntryExtensions.cs
@@ -79,19 +79,7 @@ namespace Hl7.Fhir.Rest
             }
             result.ResponseUri = response.ResponseUri;
             result.Location = response.Headers[HttpUtil.LOCATION] ?? response.Headers[HttpUtil.CONTENTLOCATION];
-
-#if NETSTANDARD1_6
-            if (!String.IsNullOrEmpty(response.Headers[HttpUtil.LASTMODIFIED]))
-            {
-                DateTimeOffset dateTimeOffset = new DateTimeOffset();
-                bool success = DateTimeOffset.TryParse(response.Headers[HttpUtil.LASTMODIFIED], out dateTimeOffset);
-                if (!success)
-                    throw new FormatException($"Last-Modified header has value '{response.Headers[HttpUtil.LASTMODIFIED]}', which is not recognized as a valid DateTime");
-                result.LastModified = dateTimeOffset;
-            }
-#else
             result.LastModified = response.LastModified;
-#endif
             result.Etag = getETag(response);
             result.ContentType = getContentType(response);
             result.Body = body;

--- a/src/Hl7.Fhir.Support.Poco/Rest/Legacy/WebClientRequester.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/Legacy/WebClientRequester.cs
@@ -41,9 +41,7 @@ namespace Hl7.Fhir.Rest
 
             var request = interaction.ToHttpWebRequest(BaseUrl, Settings);
 
-#if !NETSTANDARD1_6
             request.Timeout = Settings.Timeout;
-#endif
 
             if (Settings.PreferCompressedResponses)
             {

--- a/src/Hl7.Fhir.Support/Hl7.Fhir.Support.csproj
+++ b/src/Hl7.Fhir.Support/Hl7.Fhir.Support.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net452;netstandard1.6;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net5.0;net452;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<Import Project="..\firely-net-common.props" />

--- a/src/Hl7.Fhir.Support/Utility/ReflectionHelper.cs
+++ b/src/Hl7.Fhir.Support/Utility/ReflectionHelper.cs
@@ -196,14 +196,6 @@ namespace Hl7.Fhir.Utility
     }
 #endif
 
-#if NETSTANDARD1_6
-    public static class NetStd16TypeExtensions
-    {
-        public static bool IsAssignableFrom(this Type a, Type b) =>
-            a.GetTypeInfo().IsAssignableFrom(b.GetTypeInfo());
-    }
-#endif
-
     public static class ReflectionHelper
     {
         public static bool IsAValueType(this Type t)
@@ -249,22 +241,7 @@ namespace Hl7.Fhir.Utility
         {
             if (t == null) throw Error.ArgumentNull("t");
 
-#if NETSTANDARD1_6
-            // Unfortunately, netstandard1.6 has no method to filter on bindingflags :-(
-            // Have to do it ourselves
-            return t.GetRuntimeProperties().Where(p => hasPublicInstanceReadAccessor(p));
-            //return t.GetRuntimeProperties(); //(BindingFlags.Instance | BindingFlags.Public);
-            // return t.GetTypeInfo().DeclaredProperties.Union(t.GetTypeInfo().BaseType.GetTypeInfo().DeclaredProperties); //(BindingFlags.Instance | BindingFlags.Public);
-
-            static bool hasPublicInstanceReadAccessor(PropertyInfo p)
-            {
-                if (!p.CanRead) return false;
-                var getMethod = p.GetMethod;
-                return getMethod.IsPublic && !getMethod.IsStatic;
-            }
-#else
             return t.GetProperties(BindingFlags.Instance | BindingFlags.Public);
-#endif
         }
 
         /// <summary>

--- a/src/Hl7.Fhir.Support/Utility/SemVersion.cs
+++ b/src/Hl7.Fhir.Support/Utility/SemVersion.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Globalization;
-using System.Text;
-
-#if !NETSTANDARD
+#if NET452
 using System.Runtime.Serialization;
 using System.Security.Permissions;
 #endif
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Hl7.Fhir.Utility

--- a/src/Hl7.FhirPath/Hl7.FhirPath.csproj
+++ b/src/Hl7.FhirPath/Hl7.FhirPath.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net452;netstandard1.6;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net5.0;net452;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<Import Project="..\firely-net-common.props" />


### PR DESCRIPTION
We do not support `netstandard1.6` anymore as one of the TargetFrameworks. We follow here the [guidelines](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#when-to-target-net50-vs-netstandard) of Microsoft. 

We still support the following frameworks:
- .NET Framework 4.5.2 (`net452`).
- .NET Standard 2.0 (`netstandard2.0`)
- .NET 5.0 (`net5.0`)