### PR TITLE
Five W's support

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Introspection/FhirElementAttribute.cs
+++ b/src/Hl7.Fhir.Support.Poco/Introspection/FhirElementAttribute.cs
@@ -74,7 +74,7 @@ namespace Hl7.Fhir.Introspection
 
         public bool InSummary { get; set; }
 
-        public List<string> FiveWs { get; set; }
+        public string[] FiveWs { get; set; }
 
         // This attribute is a subclass of ValidationAttribute so that IsValid() is called on every 
         // FhirElement while validating. This allows us to extend validation into each FhirElement,

--- a/src/Hl7.Fhir.Support.Poco/Introspection/FhirElementAttribute.cs
+++ b/src/Hl7.Fhir.Support.Poco/Introspection/FhirElementAttribute.cs
@@ -74,6 +74,8 @@ namespace Hl7.Fhir.Introspection
 
         public bool InSummary { get; set; }
 
+        public List<string> FiveWs { get; set; }
+
         // This attribute is a subclass of ValidationAttribute so that IsValid() is called on every 
         // FhirElement while validating. This allows us to extend validation into each FhirElement,
         // while normally, the .NET validation will only validate one level, but will not recurse

--- a/src/Hl7.Fhir.Support.Poco/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Support.Poco/Introspection/PropertyMapping.cs
@@ -70,7 +70,7 @@ namespace Hl7.Fhir.Introspection
         public bool InSummary { get; private set; }
 
         /// <summary>
-        /// Weather the element has five ws
+        /// Five W's mappings of the element.
         /// </summary>
         public System.Collections.Generic.List<string> FiveWs { get; private set; }
 

--- a/src/Hl7.Fhir.Support.Poco/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Support.Poco/Introspection/PropertyMapping.cs
@@ -72,7 +72,7 @@ namespace Hl7.Fhir.Introspection
         /// <summary>
         /// Five W's mappings of the element.
         /// </summary>
-        public System.Collections.Generic.List<string> FiveWs { get; private set; }
+        public string[] FiveWs { get; private set; }
 
         /// <summary>
         /// Whether the element has a cardinality higher than 0.

--- a/src/Hl7.Fhir.Support.Poco/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Support.Poco/Introspection/PropertyMapping.cs
@@ -72,6 +72,9 @@ namespace Hl7.Fhir.Introspection
         /// <summary>
         /// Five W's mappings of the element.
         /// </summary>
+        /// <remarks>Each string in the array represents the exact element name of one the elements of the 
+        /// <c>FiveWs</c> pattern from http://hl7.org/fhir/fivews.html. Choice elements are spelled with the
+        /// [x] suffix, like <c>done[x]</c>. </remarks>
         public string[] FiveWs { get; private set; }
 
         /// <summary>

--- a/src/Hl7.Fhir.Support.Poco/Introspection/PropertyMapping.cs
+++ b/src/Hl7.Fhir.Support.Poco/Introspection/PropertyMapping.cs
@@ -70,6 +70,11 @@ namespace Hl7.Fhir.Introspection
         public bool InSummary { get; private set; }
 
         /// <summary>
+        /// Weather the element has five ws
+        /// </summary>
+        public System.Collections.Generic.List<string> FiveWs { get; private set; }
+
+        /// <summary>
         /// Whether the element has a cardinality higher than 0.
         /// </summary>
         public bool IsMandatoryElement { get; private set; }
@@ -216,6 +221,7 @@ namespace Hl7.Fhir.Introspection
                 IsMandatoryElement = cardinalityAttr?.Min > 0,
                 IsPrimitive = isPrimitive,
                 RepresentsValueElement = isPrimitive && isPrimitiveValueElement(elementAttr, prop),
+                FiveWs = elementAttr.FiveWs,
             };
 
             return true;


### PR DESCRIPTION
Following the discussion here: [https://github.com/FirelyTeam/firely-net-sdk/discussions/1901](https://github.com/FirelyTeam/firely-net-sdk/discussions/1901)

This PR adds the first "base" properties to allow auto generating FiveWs attribute for resources.
It simply exposes a new Property called FiveWs which is a list of strings.

Once this is approved and merged, we will be able to add the codegen the ability to generate and utilize the FiveWs proportey.