### PR TITLE
DomNode is not using Lazy<T> anymore

### DIFF
--- a/src/Hl7.Fhir.ElementModel/DomNode.cs
+++ b/src/Hl7.Fhir.ElementModel/DomNode.cs
@@ -10,6 +10,7 @@ using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Hl7.Fhir.ElementModel
 {
@@ -17,7 +18,13 @@ namespace Hl7.Fhir.ElementModel
     {
         public string Name { get; set; }
 
-        protected List<T> ChildList = new List<T>();
+        private List<T> _childList = null;
+
+        protected List<T> ChildList
+        {
+            get => LazyInitializer.EnsureInitialized(ref _childList, () => new());
+            set => _childList = value;
+        }
 
         internal IEnumerable<T> ChildrenInternal(string name = null) =>
             name == null ? ChildList : ChildList.Where(c => c.Name.MatchesPrefix(name));
@@ -29,11 +36,10 @@ namespace Hl7.Fhir.ElementModel
         public T this[int index] => ChildList[index];
 
         #region << Annotations >>
-        private readonly Lazy<AnnotationList> _annotations = new Lazy<AnnotationList>(() => new AnnotationList());
-        protected AnnotationList AnnotationsInternal { get { return _annotations.Value; } }
+        private AnnotationList _annotations = null;
+        protected AnnotationList AnnotationsInternal => LazyInitializer.EnsureInitialized(ref _annotations, () => new());
 
-        protected bool HasAnnotations =>
-            _annotations.IsValueCreated == true && _annotations.Value.IsEmpty == false;
+        protected bool HasAnnotations => _annotations is not null && !_annotations.IsEmpty;
 
         public void AddAnnotation(object annotation)
         {

--- a/src/Hl7.Fhir.ElementModel/ElementNode.cs
+++ b/src/Hl7.Fhir.ElementModel/ElementNode.cs
@@ -31,7 +31,7 @@ namespace Hl7.Fhir.ElementModel
             return value switch
             {
                 P.Quantity q => PrimitiveElement.ForQuantity(q),
-                _ => new PrimitiveElement(value, useFullTypeName:true)
+                _ => new PrimitiveElement(value, useFullTypeName: true)
             };
         }
 
@@ -89,12 +89,12 @@ namespace Hl7.Fhir.ElementModel
         /// </summary>
         /// <param name="values"></param>
         /// <returns></returns>
-        public static IEnumerable<ITypedElement> CreateList(params object[] values) => 
+        public static IEnumerable<ITypedElement> CreateList(params object[] values) =>
             values != null
-                ? values.Select(value => value == null 
-                    ? null 
+                ? values.Select(value => value == null
+                    ? null
                     : value is ITypedElement element
-                        ? element 
+                        ? element
                         : ForPrimitive(value))
                 : EmptyList;
 
@@ -172,7 +172,7 @@ namespace Hl7.Fhir.ElementModel
         /// <summary>
         /// Will update the child to reflect it being a child of this element, but will not yet add the child at any position within this element
         /// </summary>
-        private void importChild(IStructureDefinitionSummaryProvider provider, ElementNode child, string name, int? position=null)
+        private void importChild(IStructureDefinitionSummaryProvider provider, ElementNode child, string name, int? position = null)
         {
             child.Name = name ?? child.Name;
             if (child.Name == null) throw Error.Argument($"The ElementNode given should have its Name property set or the '{nameof(name)}' parameter should be given.");
@@ -180,7 +180,7 @@ namespace Hl7.Fhir.ElementModel
             // Remove this child from the current parent (if any), then reassign to me
             if (child.Parent != null) child.Parent.Remove(child);
             child.Parent = this;
-            
+
             // If we add a child, we better overwrite it's definition with what
             // we think it should be - this way you can safely first create a node representing
             // an independently created root for a resource of datatype, and then add it to the tree.
@@ -213,14 +213,14 @@ namespace Hl7.Fhir.ElementModel
                     child.InstanceType = child.Definition.Type.Single().GetTypeName();
             }
 
-            if(position == null || position >= ChildList.Count)
+            if (position == null || position >= ChildList.Count)
                 ChildList.Add(child);
             else
                 ChildList.Insert(position.Value, child);
 
         }
 
-        public static ElementNode Root(IStructureDefinitionSummaryProvider provider, string type, string name=null, object value=null)
+        public static ElementNode Root(IStructureDefinitionSummaryProvider provider, string type, string name = null, object value = null)
         {
             if (provider == null) throw Error.ArgumentNull(nameof(provider));
             if (type == null) throw Error.ArgumentNull(nameof(type));
@@ -296,7 +296,7 @@ namespace Hl7.Fhir.ElementModel
             if (type == null) throw new ArgumentNullException(nameof(type));
             return (type == typeof(ElementNode) || type == typeof(ITypedElement) || type == typeof(IShortPathGenerator))
                 ? (new[] { this })
-                : AnnotationsInternal.OfType(type);
+                : HasAnnotations ? AnnotationsInternal.OfType(type) : Enumerable.Empty<object>();
         }
 
         public string Location

--- a/src/Hl7.Fhir.ElementModel/SourceNode.cs
+++ b/src/Hl7.Fhir.ElementModel/SourceNode.cs
@@ -10,8 +10,6 @@ using Hl7.Fhir.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Collections;
-using Hl7.Fhir.Specification;
 
 namespace Hl7.Fhir.ElementModel
 {
@@ -96,7 +94,7 @@ namespace Hl7.Fhir.ElementModel
         {
             return type == typeof(SourceNode) || type == typeof(ISourceNode) || type == typeof(IResourceTypeSupplier)
                 ? (new[] { this })
-                : AnnotationsInternal.OfType(type);
+                : HasAnnotations ? AnnotationsInternal.OfType(type) : Enumerable.Empty<object>();
         }
 
         public string Location

--- a/src/Hl7.Fhir.Support.Poco/Model/Base.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Base.cs
@@ -96,7 +96,7 @@ namespace Hl7.Fhir.Model
         [NonSerialized]
         private AnnotationList _annotations = null;
 
-        private AnnotationList annotations => LazyInitializer.EnsureInitialized(ref _annotations);
+        private AnnotationList annotations => LazyInitializer.EnsureInitialized(ref _annotations, () => new());
 
         public IEnumerable<object> Annotations(Type type) => annotations.OfType(type);
 


### PR DESCRIPTION
We use now `LazyInitializer.EnsureInitialized` to reduces the amount of memory on DomNode (and so `SourceNode` and `ElementNode`)