### PR TITLE
Fix duplicate evaluation of scalar expressions

### DIFF
--- a/src/Hl7.FhirPath.Tests/Functions/FunctionsTests.cs
+++ b/src/Hl7.FhirPath.Tests/Functions/FunctionsTests.cs
@@ -527,14 +527,13 @@ namespace HL7.FhirPath.Tests
             }
         }
 
-        private static int iterations = 0;
-
         /// <summary>
         /// Check that scalar expressions are evaluated only once.
         /// </summary>
         [TestMethod]
         public void SingleScalarTest()
         {
+            var iterations = 0;
             var symbols = new SymbolTable();
 
             symbols.Add("once", (object _) =>

--- a/src/Hl7.FhirPath.Tests/Functions/FunctionsTests.cs
+++ b/src/Hl7.FhirPath.Tests/Functions/FunctionsTests.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using Hl7.FhirPath.Expressions;
+
 namespace HL7.FhirPath.Tests
 {
     [TestClass]
@@ -523,6 +525,29 @@ namespace HL7.FhirPath.Tests
                 name.Should().Be("test");
                 list.Should().HaveCount(2);
             }
+        }
+
+        private static int iterations = 0;
+
+        /// <summary>
+        /// Check that scalar expressions are evaluated only once.
+        /// </summary>
+        [TestMethod]
+        public void SingleScalarTest()
+        {
+            var symbols = new SymbolTable();
+
+            symbols.Add("once", (object _) =>
+            {
+                iterations++;
+
+                return ElementNode.CreateList(iterations);
+            });
+
+            var expression = new FhirPathCompiler(symbols).Compile("once()");
+            var result = expression.Scalar(null, new EvaluationContext());
+
+            Assert.AreEqual(result, 1);
         }
     }
 }

--- a/src/Hl7.FhirPath/FhirPath/CompiledExpression.cs
+++ b/src/Hl7.FhirPath/FhirPath/CompiledExpression.cs
@@ -12,9 +12,10 @@ namespace Hl7.FhirPath
     {
         public static object Scalar(this CompiledExpression evaluator, ITypedElement input, EvaluationContext ctx)
         {
-            var result = evaluator(input, ctx);
+            var result = evaluator(input, ctx).Take(2).ToArray();
+
             if (result.Any())
-                return evaluator(input, ctx).Single().Value;
+                return result.Single().Value;
             else
                 return null;
         }


### PR DESCRIPTION
Hi Firely,

I noticed that scalar expressions are evaluated twice in the current implementation.
This has a performance penalty and can cause problems for custom functions that maintain state.

I fixed the problem and added a unit test to validate it.
The take(2) call composes the minimal number of objects 
required to determine whether the evaluation has 0, 1 or more results.

Can you have a look?

Thanks -- Joost Schipperheijn