### PR TITLE
Move ITerminologyService and FhirOperationException to Hl7.Fhir.Support.Poco.

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Rest/FhirOperationException.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/FhirOperationException.cs
@@ -1,0 +1,99 @@
+﻿/* 
+ * Copyright (c) 2014, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+
+// [WMR 20181024] Issue #737
+// Removed serialization support from FhirOperationException (cf. all other custom exceptions)
+// Problems:
+// - NetFramework: Exception.GetObjectData override requires SecurityCritical attribute
+//    => incompatible with partial-trust environments, e.g. dotNetFiddle
+//    Alternative ISafeSerializationInfo interface is not widely supported and obsolete in netCore
+// - NetCore 1.1 : no support for serialiation
+// - NetCore 2.0 : reintroduces limited support for serialiation
+// No clear picture of use cases that depend on exception serialization; remove for now
+// If necessary, we can re-introduce serialization support in a future release (by customer demand)
+
+using Hl7.Fhir.Model;
+using System;
+using System.Net;
+
+namespace Hl7.Fhir.Rest
+{
+    /// <summary>
+    /// Represents HL7 FHIR errors that occur during application execution.
+    /// </summary>
+    public class FhirOperationException : Exception
+    {
+        /// <summary>Gets or sets the outcome of the operation <see cref="OperationOutcome"/>.</summary>
+        public OperationOutcome Outcome { get; private set; }
+
+        /// <summary>The HTTP Status Code that resulted in this Exception.</summary>
+        public HttpStatusCode Status { get; private set; }
+
+        /// <summary>Initializes a new instance of the <see cref="FhirOperationException"/> class with a specified error message.</summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="status">The http status code associated with the message</param>
+        public FhirOperationException(string message, HttpStatusCode status)
+            : this(message, status, null, null) { }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FhirOperationException"/> class with a specified error message
+        /// and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="status">The http status code associated with the message</param>
+        /// <param name="inner">The exception that is the cause of the current exception, or a <c>null</c> reference (Nothing in Visual Basic) if no inner exception is specified. </param>
+        public FhirOperationException(string message, HttpStatusCode status, Exception inner)
+            : this(message, status, null, inner) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FhirOperationException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="status">The http status code associated with the message</param>
+        /// <param name="outcome">The outcome of the operation <see cref="OperationOutcome"/>.</param>
+        public FhirOperationException(string message, HttpStatusCode status, OperationOutcome outcome)
+            : this(message, status, outcome, null) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FhirOperationException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="status">The http status code associated with the message</param>
+        /// <param name="outcome">The outcome of the operation <see cref="OperationOutcome"/>.</param>
+        /// <param name="inner">The exception that is the cause of the current exception, or a <c>null</c> reference (Nothing in Visual Basic) if no inner exception is specified. </param>
+        public FhirOperationException(string message, HttpStatusCode status, OperationOutcome outcome, Exception inner)
+            : base(message, inner)
+        {
+            Outcome = outcome;
+            Status = status;
+        }
+
+        internal static Exception BuildFhirOperationException(HttpStatusCode status, Resource body)
+        {
+            string message;
+
+            if (status.IsInformational())
+                message = $"Operation resulted in an informational response ({status})";
+            else if (status.IsRedirection())
+                message = $"Operation resulted in a redirection response ({status})";
+            else if (status.IsClientError())
+                message = $"Operation was unsuccessful because of a client error ({status})";
+            else
+                message = $"Operation was unsuccessful, and returned status {status}";
+
+            if (body is OperationOutcome outcome)
+                return new FhirOperationException($"{message}. OperationOutcome: {outcome}.", status, outcome);
+            else if (body != null)
+                return new FhirOperationException($"{message}. Body contains a {body.TypeName}.", status);
+            else
+                return new FhirOperationException($"{message}. Body has no content.", status);
+        }
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco/Specification/Terminology/ITerminologyService.cs
+++ b/src/Hl7.Fhir.Support.Poco/Specification/Terminology/ITerminologyService.cs
@@ -1,0 +1,88 @@
+﻿/* 
+ * Copyright (c) 2016, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ * 
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-net-sdk/master/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
+using System.Threading.Tasks;
+
+namespace Hl7.Fhir.Specification.Terminology
+{
+    public interface ITerminologyService
+    {
+        /// <summary>
+        /// Validate that a coded value is in the set of codes allowed by a value set.
+        /// </summary>
+        /// <param name="parameters">Input parameters for the operation</param>
+        /// <param name="id">Id of a specific ValueSet which is used to validate against</param>
+        /// <param name="useGet"> Use the GET instead of POST Http method</param>
+        /// <returns>Output parameters containing the result of the operation</returns>
+        /// <exception cref="FhirOperationException">Thrown when the terminology service encounters an error</exception>
+        /// <remarks>See http://hl7.org/valueset-operations.html#validate-code for more information</remarks>
+        Task<Parameters> ValueSetValidateCode(Parameters parameters, string id = null, bool useGet = false);
+
+        /// <summary>
+        /// Validate that a coded value is in the code system.
+        /// </summary>
+        /// <param name="parameters">Input parameters for the operation</param>
+        /// <param name="id">Id of a specific CodeSystem which is used to validate against</param>
+        /// <param name="useGet">Use the GET instead of POST Http method</param>
+        /// <returns>Output parameters containing the result of the operation</returns>
+        /// <exception cref="FhirOperationException">Thrown when the terminology service encounters an error</exception>
+        Task<Parameters> CodeSystemValidateCode(Parameters parameters, string id = null, bool useGet = false);
+
+        /// <summary>
+        /// The definition of a value set is used to create a simple collection of codes suitable for use for data entry or validation.
+        /// </summary>
+        /// <param name="parameters">Input parameters for the operation</param>
+        /// <param name="id">Id of a specific ValueSet to expand</param>
+        /// <param name="useGet">Use the GET instead of POST Http method</param>
+        /// <returns>Output parameters containing the expanded ValueSet</returns>
+        /// <exception cref="FhirOperationException">Thrown when the terminology service encounters an error</exception>
+        Task<Resource> Expand(Parameters parameters, string id = null, bool useGet = false);
+
+
+        /// <summary>
+        /// Given a code/system, or a Coding, get additional details about the concept, including definition, status, designations, and properties.
+        /// </summary>
+        /// <param name="parameters">Input parameters for the operation</param>
+        /// <param name="useGet">Use the GET instead of POST Http method</param>
+        /// <returns>Output parameters containing the result of the operation</returns>
+        /// <exception cref="FhirOperationException">Thrown when the terminology service encounters an error</exception>
+        Task<Parameters> Lookup(Parameters parameters, bool useGet = false);
+
+        /// <summary>
+        /// The transform operation takes input content, applies a structure map transform, and then returns the output.
+        /// </summary>
+        /// <param name="parameters">Input parameters for the operation</param>
+        /// <param name="id">Id of the StructureMap used for the tranformation</param>
+        /// <param name="useGet">Use the GET instead of POST Http method</param>
+        /// <returns>Output parameter containing the result of the translation</returns>
+        /// <exception cref="FhirOperationException">Thrown when the terminology service encounters an error</exception>
+        Task<Parameters> Translate(Parameters parameters, string id = null, bool useGet = false);
+
+        /// <summary>
+        /// Test the subsumption relationship between code/Coding A and code/Coding B given the semantics of subsumption in the underlying code system
+        /// </summary>
+        /// <param name="parameters">Input parameters for the operation</param>
+        /// <param name="id">Id of the code system in which subsumption testing is to be performed.</param>
+        /// <param name="useGet">Use the GET instead of POST Http method</param>
+        /// <returns>Output parameters containing the subsumption relationship between code/Coding "A" and code/Coding "B".</returns>
+        /// <exception cref="FhirOperationException">Thrown when the terminology service encounters an error</exception>
+        Task<Parameters> Subsumes(Parameters parameters, string id = null, bool useGet = false);
+
+        /// <summary>
+        /// Provides support for ongoing maintenance of a client-side transitive closure table based on server-side terminological logic. 
+        /// </summary>
+        /// <param name="parameters">Input parameters for the operation</param>
+        /// <param name="useGet">Use the GET instead of POST Http method</param>
+        /// <returns>Output parameters containing a ConceptMap with a list of new entries (code / system --> code/system) that the client should add to its closure table.</returns>
+        /// <exception cref="FhirOperationException">Thrown when the terminology service encounters an error</exception>
+        Task<Resource> Closure(Parameters parameters, bool useGet = false);
+
+    }
+}


### PR DESCRIPTION
Move the interface `ITerminologyService` and class `FhirOperationException` to library `Hl7.Fhir.Support.Poco`.

Resolves FirelyTeam/firely-net-sdk#1949