### PR TITLE
Fix timeout bug in HttpClientRequester

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Rest/HttpClientRequester.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/HttpClientRequester.cs
@@ -27,7 +27,7 @@ namespace Hl7.Fhir.Rest
 
             Client = new HttpClient(messageHandler);
             Client.DefaultRequestHeaders.Add("User-Agent", $".NET FhirClient for FHIR");
-            Client.Timeout = new TimeSpan(0, 0, 0, Settings.Timeout);
+            Client.Timeout = TimeSpan.FromMilliseconds(Settings.Timeout);
         }
 
 


### PR DESCRIPTION
`FhirClientSettings.Timeout` is a value in milliseconds, but was treated as seconds.

Note that this bug was introduced 2020-04-09, so it's possible that this has become the expected behaviour. See commit c87043532bac755f6884ed6b4d1d58ac00cc520e

Note that `WebClientRequester.ExecuteAsync()` handles `Timeout` correctly.