### PR TITLE
Added the compiler option `TreatWarningsAsErrors`

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Hl7.Fhir.Support.Poco.csproj
+++ b/src/Hl7.Fhir.Support.Poco/Hl7.Fhir.Support.Poco.csproj
@@ -26,7 +26,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Firely.Fhir.Packages" Version="3.0.0-beta2" />
+	  <PackageReference Include="Firely.Fhir.Packages" Version="3.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/firely-net-common.props
+++ b/src/firely-net-common.props
@@ -7,7 +7,7 @@
 	<!-- Solution-wide properties for NuGet packaging -->
 	<PropertyGroup>
 		<VersionPrefix>4.0.0</VersionPrefix>
-		<VersionSuffix>beta2</VersionSuffix>
+		<VersionSuffix>beta3</VersionSuffix>
 		<Authors>Firely (info@fire.ly) and contributors</Authors>
 		<Company>Firely (https://fire.ly)</Company>
 		<Copyright>Copyright 2013-2022 Firely.  Contains materials (C) HL7 International</Copyright>
@@ -40,6 +40,7 @@
 		<LangVersion>9.0</LangVersion>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Configurations>Debug;Release;FullDebug</Configurations>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'FullDebug'  ">


### PR DESCRIPTION
To enhance our code, we added the compiler option `TreatWarningsAsErrors`

Resolves issue FirelyTeam/firely-net-sdk#2034.