### PR TITLE
Additional options for HttpClient handling

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Rest/HttpClientRequester.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/HttpClientRequester.cs
@@ -19,6 +19,7 @@ namespace Hl7.Fhir.Rest
         public FhirClientSettings Settings { get; set; }
         public Uri BaseUrl { get; private set; }
         public HttpClient Client { get; private set; }
+        private bool _disposeHttpClient = true;
 
         public HttpClientRequester(Uri baseUrl, FhirClientSettings settings, HttpMessageHandler messageHandler, bool disposeHandler = true)
         {
@@ -30,6 +31,14 @@ namespace Hl7.Fhir.Rest
             Client.Timeout = new TimeSpan(0, 0, 0, Settings.Timeout);
         }
 
+        public HttpClientRequester(Uri baseUrl, FhirClientSettings settings, HttpClient client)
+        {
+            Settings = settings;
+            BaseUrl = baseUrl;
+
+            Client = client;
+            _disposeHttpClient = false;
+        }
 
         public EntryResponse LastResult { get; private set; }
 
@@ -77,11 +86,11 @@ namespace Hl7.Fhir.Rest
         {
             if (!disposedValue)
             {
-                if (disposing)
+                if (disposing && _disposeHttpClient)
                 {
+                    // Only dispose the httpclient if was created here
                     this.Client.Dispose();
                 }
-
                 disposedValue = true;
             }
         }


### PR DESCRIPTION
Support caller provided HttpClient, not just caller provided HttpClientHandler.
This will permit callers to use their own HttpClient such as in use cases like unit testing as shown in this blog post
https://www.hanselman.com/blog/minimal-apis-in-net-6-but-where-are-the-unit-tests
(additional PR coming to the fhir client too)

Relevant to this Issue https://github.com/FirelyTeam/firely-net-sdk/issues/2036