### PR TITLE
Check for null reference when trying to use a FHIR operation without a body [common]

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Rest/HttpClientRequester.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/HttpClientRequester.cs
@@ -60,7 +60,7 @@ namespace Hl7.Fhir.Rest
             }
 
             byte[] outgoingBody = null;
-            if (requestMessage.Method == HttpMethod.Post || requestMessage.Method == HttpMethod.Put)
+            if (requestMessage.Content is not null && (requestMessage.Method == HttpMethod.Post || requestMessage.Method == HttpMethod.Put))
             {
                 outgoingBody = await requestMessage.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             }


### PR DESCRIPTION
fixes: [#2073](https://github.com/FirelyTeam/firely-net-sdk/issues/2073)