### PR TITLE
2018 Make sure repeats() does not hang when given a constant argument

### DIFF
--- a/src/Hl7.FhirPath.Tests/Functions/FunctionsTests.cs
+++ b/src/Hl7.FhirPath.Tests/Functions/FunctionsTests.cs
@@ -2,12 +2,11 @@
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.FhirPath;
+using Hl7.FhirPath.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
-using Hl7.FhirPath.Expressions;
 
 namespace HL7.FhirPath.Tests
 {
@@ -528,7 +527,7 @@ namespace HL7.FhirPath.Tests
             }
         }
 
-        
+
         /// <summary>
         /// Check that scalar expressions are evaluated only once.
         /// </summary>
@@ -550,7 +549,7 @@ namespace HL7.FhirPath.Tests
 
             Assert.AreEqual(result, 1);
         }
-      
+
         /// <summary>
         /// Tests issue 1652 https://github.com/FirelyTeam/firely-net-sdk/issues/1652
         /// </summary>
@@ -566,5 +565,16 @@ namespace HL7.FhirPath.Tests
             Assert.IsTrue(te.IsBoolean($"system.endsWith('banana')", false));
         }
 
+        /// <summary>
+        /// Tests issue https://github.com/FirelyTeam/firely-net-sdk/issues/2018
+        /// </summary>
+        [TestMethod]
+        public void TestFhirPathRepeatsStringLiteral()
+        {
+            var nav = ElementNode.ForPrimitive("a");
+
+            var result = nav.Select("repeat('teststring')");
+            result.Should().ContainSingle(ite => ((string)ite.Value) == "teststring");
+        }
     }
 }

--- a/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTableInit.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTableInit.cs
@@ -346,7 +346,10 @@ namespace Hl7.FhirPath.Expressions
                     newContext.SetIndex(ElementNode.CreateList(index));
                     index++;
 
-                    newNodes.AddRange(lambda(newContext, InvokeeFactory.EmptyArgs));
+                    var candidates = lambda(newContext, InvokeeFactory.EmptyArgs);
+                    var uniqeNewNodes = candidates.Where(c => !fullResult.Contains(c, EqualityOperators.TypedElementEqualityComparer));
+
+                    newNodes.AddRange(uniqeNewNodes);
                 }
 
                 fullResult.AddRange(newNodes);

--- a/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTableInit.cs
+++ b/src/Hl7.FhirPath/FhirPath/Expressions/SymbolTableInit.cs
@@ -347,7 +347,7 @@ namespace Hl7.FhirPath.Expressions
                     index++;
 
                     var candidates = lambda(newContext, InvokeeFactory.EmptyArgs);
-                    var uniqeNewNodes = candidates.Where(c => !fullResult.Contains(c, EqualityOperators.TypedElementEqualityComparer));
+                    var uniqeNewNodes = candidates.Except(fullResult, EqualityOperators.TypedElementEqualityComparer);
 
                     newNodes.AddRange(uniqeNewNodes);
                 }

--- a/src/Hl7.FhirPath/FhirPath/FhirPathCompiler.cs
+++ b/src/Hl7.FhirPath/FhirPath/FhirPathCompiler.cs
@@ -41,7 +41,7 @@ namespace Hl7.FhirPath
 
 #pragma warning disable CA1822 // Mark members as static
         public Expression Parse(string expression)
-#pragma warning restore CA1822 // This might access instane data in the future.
+#pragma warning restore CA1822 // This might access instance data in the future.
         {
             var parse = Grammar.Expression.End().TryParse(expression);
 

--- a/src/Hl7.FhirPath/FhirPath/Functions/CollectionOperators.cs
+++ b/src/Hl7.FhirPath/FhirPath/Functions/CollectionOperators.cs
@@ -36,7 +36,7 @@ namespace Hl7.FhirPath.Functions
             : !focus.BooleanEval().Value;
 
         public static IEnumerable<ITypedElement> DistinctUnion(this IEnumerable<ITypedElement> a, IEnumerable<ITypedElement> b)
-            => a.Union(b, new EqualityOperators.ValueProviderEqualityComparer());
+            => a.Union(b, EqualityOperators.TypedElementEqualityComparer);
 
         public static IEnumerable<ITypedElement> Item(this IEnumerable<ITypedElement> focus, int index)
             => focus.Skip(index).Take(1);
@@ -48,19 +48,19 @@ namespace Hl7.FhirPath.Functions
             => focus.Skip(1);
 
         public static bool Contains(this IEnumerable<ITypedElement> focus, ITypedElement value)
-            => focus.Contains(value, new EqualityOperators.ValueProviderEqualityComparer());
+            => focus.Contains(value, EqualityOperators.TypedElementEqualityComparer);
 
         public static IEnumerable<ITypedElement> Distinct(this IEnumerable<ITypedElement> focus)
-            => focus.Distinct(new EqualityOperators.ValueProviderEqualityComparer());
+            => focus.Distinct(EqualityOperators.TypedElementEqualityComparer);
 
         public static bool IsDistinct(this IEnumerable<ITypedElement> focus)
-            => focus.Distinct(new EqualityOperators.ValueProviderEqualityComparer()).Count() == focus.Count();
+            => focus.Distinct(EqualityOperators.TypedElementEqualityComparer).Count() == focus.Count();
 
         public static bool SubsetOf(this IEnumerable<ITypedElement> focus, IEnumerable<ITypedElement> other)
             => focus.All(fitem => other.Contains(fitem));
 
         public static IEnumerable<ITypedElement> Intersect(this IEnumerable<ITypedElement> focus, IEnumerable<ITypedElement> other)
-            => focus.Intersect(other, new EqualityOperators.ValueProviderEqualityComparer());
+            => focus.Intersect(other, EqualityOperators.TypedElementEqualityComparer);
 
         public static IEnumerable<ITypedElement> Exclude(this IEnumerable<ITypedElement> focus, IEnumerable<ITypedElement> other)
             => focus.Where(f => !other.Contains(f));

--- a/src/Hl7.FhirPath/FhirPath/Functions/EqualityOperators.cs
+++ b/src/Hl7.FhirPath/FhirPath/Functions/EqualityOperators.cs
@@ -239,8 +239,9 @@ namespace Hl7.FhirPath.Functions
             }
         }
 
+        public static readonly IEqualityComparer<ITypedElement> TypedElementEqualityComparer = new ValueProviderEqualityComparer();
 
-        internal class ValueProviderEqualityComparer : IEqualityComparer<ITypedElement>
+        private class ValueProviderEqualityComparer : IEqualityComparer<ITypedElement>
         {
             public bool Equals(ITypedElement? x, ITypedElement? y)
             {


### PR DESCRIPTION
Updated the repeat() algorithm to enforce uniqueness of newly added items.