### PR TITLE
2192 - Make Response Headers case insensitive

### DIFF
--- a/src/Hl7.Fhir.Support.Poco.Tests/HttpToEntryExtensionsTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/HttpToEntryExtensionsTests.cs
@@ -1,0 +1,43 @@
+﻿using FluentAssertions;
+using Hl7.Fhir.Rest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+
+namespace Hl7.Fhir.Support.Poco.Tests
+{
+
+    [TestClass]
+    public class HttpToEntryExtensionsTests
+    {
+
+        [TestMethod]
+        public void ResponseHeadersCaseInsensitiveTest()
+        {
+            var headers = new WebHeaderCollection
+            {
+                { "LOWERCASE", "value" }
+            };
+
+            var mock = new Mock<HttpWebResponse>();
+            mock.Setup(c => c.Headers).Returns(headers);
+            var httpWebResponse = mock.Object;
+
+            // a bit of an hack to make HttpWebResponse happy
+            var field = typeof(HttpWebResponse).GetField("_httpResponseMessage",
+                         BindingFlags.NonPublic |
+                         BindingFlags.Instance);
+            field.SetValue(httpWebResponse, new HttpResponseMessage());
+
+            // act
+            var entryResponse = httpWebResponse.ToEntryResponse(Array.Empty<byte>());
+
+            // assert
+            entryResponse.Headers.Should().BeEquivalentTo(new Dictionary<string, string> { { "lowercase", "value" } });
+        }
+    }
+}

--- a/src/Hl7.Fhir.Support.Poco.Tests/HttpToEntryExtensionsTests.cs
+++ b/src/Hl7.Fhir.Support.Poco.Tests/HttpToEntryExtensionsTests.cs
@@ -39,5 +39,25 @@ namespace Hl7.Fhir.Support.Poco.Tests
             // assert
             entryResponse.Headers.Should().BeEquivalentTo(new Dictionary<string, string> { { "lowercase", "value" } });
         }
+
+        [TestMethod]
+        public void ResponseHeadersCaseInsensitiveTest2()
+        {
+            var responseMessage = new HttpResponseMessage
+            {
+                RequestMessage = new HttpRequestMessage()
+            };
+            responseMessage.Headers.Add("LOWERCASE", "value");
+            responseMessage.Headers.Add("ANOTHERHEADER", new[] { "value1", "value2" });
+
+            // act
+            var entryResponse = responseMessage.ToEntryResponse(Array.Empty<byte>());
+
+            // assert
+            entryResponse.Headers.Should().BeEquivalentTo(new Dictionary<string, string>
+            {   { "lowercase", "value" },
+                { "anotherheader", "value1"}  // value2 is ignored 
+            });
+        }
     }
 }

--- a/src/Hl7.Fhir.Support.Poco/Rest/EntryResponse.cs
+++ b/src/Hl7.Fhir.Support.Poco/Rest/EntryResponse.cs
@@ -15,17 +15,17 @@ namespace Hl7.Fhir.Rest
     public class EntryResponse
     {
         public string Status { get; set; }
-        public Dictionary<string,string> Headers { get; set; }
+        public Dictionary<string, string> Headers { get; set; }
         public DateTimeOffset? LastModified { get; set; }
         public string ContentType { get; set; }
         public string Etag { get; set; }
         public byte[] Body { get; set; }
         public string Location { get; set; }
-        public Uri ResponseUri { get; set; } 
+        public Uri ResponseUri { get; set; }
 
         public EntryResponse()
         {
-            Headers = new Dictionary<string, string>();
+            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
     }
 


### PR DESCRIPTION
The headers in `EntryResponse` are now treated as case insensitive headers.

Resolves FirelyTeam/firely-net-sdk#2192