### PR TITLE
Fix NullRefEx on FhirDateTime.TryToDateTimeOffset 

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Model/FhirDateTime.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/FhirDateTime.cs
@@ -143,7 +143,7 @@ namespace Hl7.Fhir.Model
         {
             dto = default;
 
-            if (this.Value == null)
+            if (this == null || this.Value == null)
                 return false;
 
             if (tryGetTimeSpan(out var timespan))


### PR DESCRIPTION
When FhirDateTime is null and you try to invoke TryToDatetimeOffset it throws a NullReferenceException.

Try-Methods shouldn't do that and instead respond with false.

[#2218](https://github.com/FirelyTeam/firely-net-sdk/issues/2218)