### PR TITLE
Remove rule on DomainResource that contained resources cannot have narrative [common]

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Model/DomainResource.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/DomainResource.cs
@@ -48,9 +48,6 @@ namespace Hl7.Fhir.Model
 
             if (this.Contained != null)
             {
-                if (!Contained.OfType<DomainResource>().All(dr => dr.Text == null))
-                    result.Add(COVE.CONTAINED_RESOURCE_CANNOT_HAVE_NARRATIVE.AsResult(validationContext));
-
                 if (!Contained.OfType<DomainResource>().All(cr => cr.Contained == null || !cr.Contained.Any()))
                     result.Add(COVE.CONTAINED_RESOURCES_CANNOT_BE_NESTED.AsResult(validationContext));
             }


### PR DESCRIPTION
Fixes: FirelyTeam/firely-net-sdk#2155