### PR TITLE
#2268 include accessors and additional constructor for Canonical components

### DIFF
--- a/src/Hl7.Fhir.Support.Poco/Model/Canonical.cs
+++ b/src/Hl7.Fhir.Support.Poco/Model/Canonical.cs
@@ -1,33 +1,35 @@
 ﻿/*
   Copyright (c) 2011+, HL7, Inc.
   All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without modification, 
+
+  Redistribution and use in source and binary forms, with or without modification,
   are permitted provided that the following conditions are met:
-  
-   * Redistributions of source code must retain the above copyright notice, this 
+
+   * Redistributions of source code must retain the above copyright notice, this
      list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above copyright notice, 
-     this list of conditions and the following disclaimer in the documentation 
+   * Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   * Neither the name of HL7 nor the names of its contributors may be used to 
-     endorse or promote products derived from this software without specific 
+   * Neither the name of HL7 nor the names of its contributors may be used to
+     endorse or promote products derived from this software without specific
      prior written permission.
-  
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
- 
+
 */
 
+using Hl7.Fhir.Utility;
 using System;
+using System.Text;
 
 #nullable enable
 
@@ -42,6 +44,34 @@ namespace Hl7.Fhir.Model
         public Canonical(Uri uri) : this(uri?.OriginalString)
         {
             // nothing
+        }
+
+        /// <summary>
+        /// Create a new Canonical from multiple components
+        /// </summary>
+        /// <param name="canonicalUrl">A raw canonical URL (with no version or fragment components)</param>
+        /// <param name="canonicalVersion">A canonical version</param>
+        /// <param name="fragment">A fragment reference within the canonical</param>
+        /// <returns>A new Canonical instance preformatted with the parameters provided</returns>
+        public Canonical(string canonicalUrl, string? canonicalVersion, string? fragment = null)
+        {
+            if (canonicalUrl == null) throw Error.ArgumentNull(nameof(canonicalUrl));
+            if (canonicalUrl.IndexOfAny(new[] { '|', '#' }) != -1)
+                throw Error.Argument(nameof(canonicalUrl), "cannot contain version/fragment data");
+
+            if (canonicalVersion != null && canonicalVersion.IndexOfAny(new[] { '|', '#' }) != -1)
+                throw Error.Argument(nameof(canonicalVersion), "cannot contain version/fragment data");
+
+            if (fragment != null && fragment.IndexOfAny(new[] { '|', '#' }) != -1)
+                throw Error.Argument(nameof(fragment), "already contains version/fragment data");
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append(canonicalUrl);
+            if (!string.IsNullOrEmpty(canonicalVersion))
+                sb.Append($"|{canonicalVersion}");
+            if (!string.IsNullOrEmpty(fragment))
+                sb.Append($"#{fragment}");
+            this.Value = sb.ToString();
         }
 
         /// <summary>
@@ -60,6 +90,89 @@ namespace Hl7.Fhir.Model
         /// Checks whether the given literal is correctly formatted.
         /// </summary>
         public static bool IsValidValue(string value) => FhirUri.IsValidValue(value);
+
+        /// <summary>
+        /// The raw canonical value, excluding any version (after |) or fragment (after #) components
+        /// </summary>
+        /// <remarks>
+        /// This would be found in the `Url` property of a referenced canonical resource
+        /// </remarks>
+        public string CanonicalUrl
+        {
+            get
+            {
+                int indexOfVersion = Value.IndexOf("|");
+                if (indexOfVersion != -1)
+                    return Value.Substring(0, indexOfVersion);
+                int indexOfFragment = Value.IndexOf("#");
+                if (indexOfFragment != -1)
+                    return Value.Substring(0, indexOfFragment);
+                return Value;
+            }
+            set
+            {
+                Value = new Canonical(value, CanonicalVersion, Fragment).Value;
+            }
+        }
+
+        /// <summary>
+        /// The canonical version (if any) included on the URL
+        /// </summary>
+        /// <remarks>
+        /// This would be found in the `Version` property of a referenced canonical resource
+        /// </remarks>
+        public string? CanonicalVersion
+        {
+            get
+            {
+                int indexOfVersion = Value.IndexOf("|");
+                if (indexOfVersion == -1)
+                    return null;
+                var result = Value.Substring(indexOfVersion + 1);
+                int indexOfFragment = result.IndexOf("#");
+                if (indexOfFragment != -1)
+                    return result.Substring(0, indexOfFragment);
+                return result;
+
+            }
+            set
+            {
+                Value = new Canonical(CanonicalUrl, value, Fragment).Value;
+            }
+        }
+
+        public string? Fragment
+        {
+            get
+            {
+                int indexOfFragment = Value.IndexOf("#");
+                if (indexOfFragment != -1)
+                    return Value.Substring(indexOfFragment + 1);
+                return null;
+            }
+            set
+            {
+                Value = new Canonical(CanonicalUrl, CanonicalVersion, value).Value;
+            }
+        }
+
+        /// <summary>
+        /// Is a Version component present in the Canonical
+        /// </summary>
+        /// <returns></returns>
+        public bool HasVersion()
+        {
+            return this.Value?.Contains("|") == true;
+        }
+
+        /// <summary>
+        /// Is a Fragment component present in the Canonical
+        /// </summary>
+        /// <returns></returns>
+        public bool HasFragment()
+        {
+            return this.Value?.Contains("#") == true;
+        }
     }
 }
 

--- a/src/Hl7.Fhir.Support.Tests/Utility/CanonicalTests.cs
+++ b/src/Hl7.Fhir.Support.Tests/Utility/CanonicalTests.cs
@@ -1,0 +1,50 @@
+﻿using Hl7.Fhir.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using static Hl7.Fhir.Utility.Result;
+
+namespace Hl7.Fhir.Utility.Tests
+{
+    [TestClass]
+    public class CanonicalTests
+    {
+        [TestMethod]
+        public void CanonicalTest()
+        {
+            var r = Ok(4);
+            Assert.AreEqual(10, r + 6);
+            Canonical c1 = new Canonical("http://example.org/StrucutureDefinition/Condition", null);
+            Assert.AreEqual("http://example.org/StrucutureDefinition/Condition", c1.Value);
+            Assert.AreEqual("http://example.org/StrucutureDefinition/Condition", c1.CanonicalUrl);
+            Assert.IsNull(c1.CanonicalVersion);
+            Assert.IsNull(c1.Fragment);
+
+            Canonical c2 = new Canonical("http://example.org/StrucutureDefinition/Condition", "2022-10");
+            Assert.AreEqual("http://example.org/StrucutureDefinition/Condition|2022-10", c2.Value);
+            Assert.AreEqual("http://example.org/StrucutureDefinition/Condition", c2.CanonicalUrl);
+            Assert.AreEqual("2022-10", c2.CanonicalVersion);
+            Assert.IsNull(c2.Fragment);
+
+            Canonical c3 = new Canonical("http://example.org/StrucutureDefinition/Condition", "2022-10", "code");
+            Assert.AreEqual("http://example.org/StrucutureDefinition/Condition|2022-10#code", c3.Value);
+            Assert.AreEqual("http://example.org/StrucutureDefinition/Condition", c3.CanonicalUrl);
+            Assert.AreEqual("2022-10", c3.CanonicalVersion);
+            Assert.AreEqual("code", c3.Fragment);
+
+            Canonical c4 = new Canonical("http://example.org/StrucutureDefinition/Condition", null, "code");
+            Assert.AreEqual("http://example.org/StrucutureDefinition/Condition#code", c4.Value);
+            Assert.AreEqual("http://example.org/StrucutureDefinition/Condition", c4.CanonicalUrl);
+            Assert.IsNull(c4.CanonicalVersion);
+            Assert.AreEqual("code", c4.Fragment);
+
+            Assert.ThrowsException<ArgumentException>(() => new Canonical("http://example.org/StrucutureDefinition/Condition|", null));
+            Assert.ThrowsException<ArgumentException>(() => new Canonical("http://example.org/StrucutureDefinition/Condition#", null));
+
+            Assert.ThrowsException<ArgumentException>(() => new Canonical("http://example.org/StrucutureDefinition/Condition", "#bla"));
+            Assert.ThrowsException<ArgumentException>(() => new Canonical("http://example.org/StrucutureDefinition/Condition", "|ba"));
+
+            Assert.ThrowsException<ArgumentException>(() => new Canonical("http://example.org/StrucutureDefinition/Condition", null, "#bla"));
+            Assert.ThrowsException<ArgumentException>(() => new Canonical("http://example.org/StrucutureDefinition/Condition", null, "|ba"));
+        }
+    }
+}


### PR DESCRIPTION
This implements the functionality requested by [#2268 (in the FirelyTeam SDK repo)](https://github.com/FirelyTeam/firely-net-sdk/issues/2268)
It includes a unit test that verifies all the behaviours that I would have expected.